### PR TITLE
Update MSVC project files

### DIFF
--- a/msvc/examples/FormatterHooks.vcxproj
+++ b/msvc/examples/FormatterHooks.vcxproj
@@ -400,7 +400,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\examples\FormatterHooks.c" />
-    <ClInclude Include="..\..\examples\FormatHelper.h" />
+  </ItemGroup>
+  <ItemGroup>
     <ClInclude Include="..\..\include\Zydis\CommonTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Defines.h" />
     <ClInclude Include="..\..\include\Zydis\MetaInfo.h" />
@@ -408,6 +409,7 @@
     <ClInclude Include="..\..\include\Zydis\Register.h" />
     <ClInclude Include="..\..\include\Zydis\SharedTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Status.h" />
+    <ClInclude Include="..\..\include\Zydis\String.h" />
     <ClInclude Include="..\..\include\Zydis\Utils.h" />
     <ClInclude Include="..\..\include\Zydis\Zydis.h" />
     <ClInclude Include="..\..\include\Zydis\Decoder.h" />

--- a/msvc/examples/FormatterHooks.vcxproj.filters
+++ b/msvc/examples/FormatterHooks.vcxproj.filters
@@ -16,9 +16,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\examples\FormatHelper.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\Zydis\CommonTypes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -38,6 +35,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Status.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\String.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Utils.h">

--- a/msvc/examples/ZydisFuzzIn.vcxproj
+++ b/msvc/examples/ZydisFuzzIn.vcxproj
@@ -400,6 +400,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\examples\ZydisFuzzIn.c" />
+  </ItemGroup>
+  <ItemGroup>
     <ClInclude Include="..\..\include\Zydis\CommonTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Defines.h" />
     <ClInclude Include="..\..\include\Zydis\MetaInfo.h" />
@@ -407,6 +409,7 @@
     <ClInclude Include="..\..\include\Zydis\Register.h" />
     <ClInclude Include="..\..\include\Zydis\SharedTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Status.h" />
+    <ClInclude Include="..\..\include\Zydis\String.h" />
     <ClInclude Include="..\..\include\Zydis\Utils.h" />
     <ClInclude Include="..\..\include\Zydis\Zydis.h" />
     <ClInclude Include="..\..\include\Zydis\Decoder.h" />

--- a/msvc/examples/ZydisFuzzIn.vcxproj.filters
+++ b/msvc/examples/ZydisFuzzIn.vcxproj.filters
@@ -37,6 +37,9 @@
     <ClInclude Include="..\..\include\Zydis\Status.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\String.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/msvc/examples/ZydisPerfTest.vcxproj
+++ b/msvc/examples/ZydisPerfTest.vcxproj
@@ -400,6 +400,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\examples\ZydisPerfTest.c" />
+  </ItemGroup>
+  <ItemGroup>
     <ClInclude Include="..\..\include\Zydis\CommonTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Defines.h" />
     <ClInclude Include="..\..\include\Zydis\MetaInfo.h" />
@@ -407,6 +409,7 @@
     <ClInclude Include="..\..\include\Zydis\Register.h" />
     <ClInclude Include="..\..\include\Zydis\SharedTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Status.h" />
+    <ClInclude Include="..\..\include\Zydis\String.h" />
     <ClInclude Include="..\..\include\Zydis\Utils.h" />
     <ClInclude Include="..\..\include\Zydis\Zydis.h" />
     <ClInclude Include="..\..\include\Zydis\Decoder.h" />

--- a/msvc/examples/ZydisPerfTest.vcxproj.filters
+++ b/msvc/examples/ZydisPerfTest.vcxproj.filters
@@ -37,6 +37,9 @@
     <ClInclude Include="..\..\include\Zydis\Status.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\String.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/msvc/examples/ZydisWinKernel.vcxproj
+++ b/msvc/examples/ZydisWinKernel.vcxproj
@@ -214,6 +214,7 @@
     <ClInclude Include="..\..\include\Zydis\Register.h" />
     <ClInclude Include="..\..\include\Zydis\SharedTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Status.h" />
+    <ClInclude Include="..\..\include\Zydis\String.h" />
     <ClInclude Include="..\..\include\Zydis\Utils.h" />
     <ClInclude Include="..\..\include\Zydis\Zydis.h" />
     <ClInclude Include="..\..\include\Zydis\Decoder.h" />

--- a/msvc/examples/ZydisWinKernel.vcxproj.filters
+++ b/msvc/examples/ZydisWinKernel.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClInclude Include="..\..\include\Zydis\Status.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\String.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/msvc/tools/ZydisDisasm.vcxproj
+++ b/msvc/tools/ZydisDisasm.vcxproj
@@ -400,6 +400,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\tools\ZydisDisasm.c" />
+  </ItemGroup>
+  <ItemGroup>
     <ClInclude Include="..\..\include\Zydis\CommonTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Defines.h" />
     <ClInclude Include="..\..\include\Zydis\MetaInfo.h" />
@@ -407,6 +409,7 @@
     <ClInclude Include="..\..\include\Zydis\Register.h" />
     <ClInclude Include="..\..\include\Zydis\SharedTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Status.h" />
+    <ClInclude Include="..\..\include\Zydis\String.h" />
     <ClInclude Include="..\..\include\Zydis\Utils.h" />
     <ClInclude Include="..\..\include\Zydis\Zydis.h" />
     <ClInclude Include="..\..\include\Zydis\Decoder.h" />

--- a/msvc/tools/ZydisDisasm.vcxproj.filters
+++ b/msvc/tools/ZydisDisasm.vcxproj.filters
@@ -37,6 +37,9 @@
     <ClInclude Include="..\..\include\Zydis\Status.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\String.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/msvc/tools/ZydisInfo.vcxproj
+++ b/msvc/tools/ZydisInfo.vcxproj
@@ -400,6 +400,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\tools\ZydisInfo.c" />
+  </ItemGroup>
+  <ItemGroup>
     <ClInclude Include="..\..\include\Zydis\CommonTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Defines.h" />
     <ClInclude Include="..\..\include\Zydis\MetaInfo.h" />
@@ -407,6 +409,7 @@
     <ClInclude Include="..\..\include\Zydis\Register.h" />
     <ClInclude Include="..\..\include\Zydis\SharedTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Status.h" />
+    <ClInclude Include="..\..\include\Zydis\String.h" />
     <ClInclude Include="..\..\include\Zydis\Utils.h" />
     <ClInclude Include="..\..\include\Zydis\Zydis.h" />
     <ClInclude Include="..\..\include\Zydis\Decoder.h" />

--- a/msvc/tools/ZydisInfo.vcxproj.filters
+++ b/msvc/tools/ZydisInfo.vcxproj.filters
@@ -37,6 +37,9 @@
     <ClInclude Include="..\..\include\Zydis\Status.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\String.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/msvc/zydis/Zydis.vcxproj
+++ b/msvc/zydis/Zydis.vcxproj
@@ -509,12 +509,12 @@
     <ClCompile Include="..\..\src\Mnemonic.c" />
     <ClCompile Include="..\..\src\Register.c" />
     <ClCompile Include="..\..\src\SharedData.c" />
+    <ClCompile Include="..\..\src\String.c" />
     <ClCompile Include="..\..\src\Utils.c" />
     <ClCompile Include="..\..\src\Zydis.c" />
     <ClCompile Include="..\..\src\Decoder.c" />
     <ClCompile Include="..\..\src\DecoderData.c" />
     <ClCompile Include="..\..\src\Formatter.c" />
-    <ClCompile Include="..\..\src\FormatHelper.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\Zydis\CommonTypes.h" />
@@ -524,15 +524,15 @@
     <ClInclude Include="..\..\include\Zydis\Register.h" />
     <ClInclude Include="..\..\include\Zydis\SharedTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Status.h" />
+    <ClInclude Include="..\..\include\Zydis\String.h" />
     <ClInclude Include="..\..\include\Zydis\Utils.h" />
     <ClInclude Include="..\..\include\Zydis\Zydis.h" />
     <ClInclude Include="..\..\include\Zydis\Decoder.h" />
     <ClInclude Include="..\..\include\Zydis\DecoderTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Formatter.h" />
-    <ClInclude Include="..\..\src\DecoderData.h" />
-    <ClInclude Include="..\..\src\FormatHelper.h" />
-    <ClInclude Include="..\..\src\LibC.h" />
-    <ClInclude Include="..\..\src\SharedData.h" />
+    <ClInclude Include="..\..\include\Zydis\Internal\LibC.h" />
+    <ClInclude Include="..\..\include\Zydis\Internal\SharedData.h" />
+    <ClInclude Include="..\..\include\Zydis\Internal\DecoderData.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\VersionInfo.rc">

--- a/msvc/zydis/Zydis.vcxproj.filters
+++ b/msvc/zydis/Zydis.vcxproj.filters
@@ -13,8 +13,8 @@
       <UniqueIdentifier>{97DEB7A2-7CAF-45B9-B945-FA454AAAC4FB}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
-    <Filter Include="Header Files\Zydis">
-      <UniqueIdentifier>{FCE9C51F-A1C2-4A67-897E-FD341CF564C2}</UniqueIdentifier>
+    <Filter Include="Header Files\Internal">
+      <UniqueIdentifier>{CEA317BE-1F0E-40DD-A546-67659EB71E9A}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -22,9 +22,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\DecoderData.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\FormatHelper.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Formatter.c">
@@ -42,6 +39,9 @@
     <ClCompile Include="..\..\src\SharedData.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\String.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -50,53 +50,53 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\SharedData.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\DecoderData.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\FormatHelper.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\LibC.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\Zydis\CommonTypes.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Decoder.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\DecoderTypes.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Defines.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Formatter.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\MetaInfo.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Mnemonic.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Register.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\SharedTypes.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Status.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\String.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Utils.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Zydis.h">
-      <Filter>Header Files\Zydis</Filter>
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\Internal\LibC.h">
+      <Filter>Header Files\Internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\Internal\SharedData.h">
+      <Filter>Header Files\Internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\Zydis\Internal\DecoderData.h">
+      <Filter>Header Files\Internal</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi,

This updates the MSVC project files to match the current CMakeLists.txt. I've removed the 'Header Files\Zydis' project filter and moved these to simply 'Header Files', since there are now no longer any headers under `/src`.