### PR TITLE
New formatting options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 include(GenerateExportHeader)
 include(GNUInstallDirs)
 
-project(Zydis VERSION 2.0.2)
+project(Zydis VERSION 2.1.0)
 
 # =============================================================================================== #
 # Overridable options                                                                             #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 include(GenerateExportHeader)
 include(GNUInstallDirs)
 
-project(Zydis VERSION 2.1.0)
+project(Zydis VERSION 2.0.2)
 
 # =============================================================================================== #
 # Overridable options                                                                             #

--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -632,8 +632,8 @@ typedef ZydisStatus (*ZydisFormatterDecoratorFunc)(const ZydisFormatter* formatt
 struct ZydisFormatter_
 {
     ZydisLetterCase letterCase;
-    ZydisBool forceMemorySegment;
-    ZydisBool forceMemorySize;
+    ZydisBool forceorySegment;
+    ZydisBool forceorySize;
     ZydisU8 formatAddress;
     ZydisU8 formatDisp;
     ZydisU8 formatImm;

--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -114,7 +114,7 @@ enum ZydisFormatterProperties
     /**
      * @brief   Controls the format of addresses.
      *
-     * The default value is `ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE`.
+     * The default value is `ZYDIS_ADDR_FORMAT_ABSOLUTE`.
      */
     ZYDIS_FORMATTER_PROP_ADDR_FORMAT,
     /**
@@ -168,47 +168,11 @@ enum ZydisFormatterProperties
      * The default value is `2`.
      */
     ZYDIS_FORMATTER_PROP_HEX_PADDING_IMM,
-    /**
-     * @brief   Controls whether machine language bytecodes are printed.
-     *
-     *          The bytes are printed in hexadecimal.  The ZYDIS_FORMATTER_PROP_HEX_UPPERCASE
-     *          setting is honored, but prefix, suffix and padding settings are not.
-     *          The instruction itself is printed on the next line.
-     *
-     * The default value is `ZYDIS_FALSE`.
-     */
-    ZYDIS_FORMATTER_PROP_PRINT_BYTES,
-    /**
-     * @brief   Controls whether the instruction address is printed.
-     *
-     *          The formatting options set for addresses are followed.
-     *          The instruction itself is printed on the next line.
-     *
-     * The default value is `ZYDIS_FALSE`.
-     */
-    ZYDIS_FORMATTER_PROP_PRINT_INSN_ADDR,
-    /**
-     * @brief   Controls the indentation of the printed instruction.
-     *
-     * The default value is `0`.
-     */
-    ZYDIS_FORMATTER_PROP_INDENTATION,
-    /**
-     * @brief   Controls whether hexadecimal values are padded when printed.
-     *
-     *          Padded hexadecimal values are printed with leading zeroes
-     *          to fill out the desired width (8-bit, 16-bit, etc.).
-     *          Setting this flag to `ZYDIS_FALSE` will override the
-     *          values of ZYDIS_FORMATTER_PROP_HEX_PADDING_ADDR,
-     *          ZYDIS_FORMATTER_PROP_HEX_PADDING_IMM and ZYDIS_FORMATTER_PROP_HEX_PADDING_DISP.
-     *
-     * The default value is `ZYDIS_TRUE`.
-     */
-    ZYDIS_FORMATTER_PROP_HEX_PADDING,
+
     /**
      * @brief   Maximum value of this enum.
      */
-    ZYDIS_FORMATTER_PROP_MAX_VALUE = ZYDIS_FORMATTER_PROP_HEX_PADDING
+    ZYDIS_FORMATTER_PROP_MAX_VALUE = ZYDIS_FORMATTER_PROP_HEX_PADDING_IMM
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -225,8 +189,6 @@ enum ZydisAddressFormat
      *
      * Using this value will cause the formatter to invoke `ZYDIS_FORMATTER_HOOK_PRINT_ADDRESS`
      * for every address.
-     *
-     * This is NOT the default setting.
      */
     ZYDIS_ADDR_FORMAT_ABSOLUTE,
     /**
@@ -238,8 +200,6 @@ enum ZydisAddressFormat
      * Examples:
      * - `"JMP  0x20"`
      * - `"JMP -0x20"`
-     *
-     * This is NOT the default setting.
      */
     ZYDIS_ADDR_FORMAT_RELATIVE_SIGNED,
     /**
@@ -251,24 +211,13 @@ enum ZydisAddressFormat
      * Examples:
      * - `"JMP 0x20"`
      * - `"JMP 0xE0"`
-     *
-     * This is NOT the default setting.
      */
     ZYDIS_ADDR_FORMAT_RELATIVE_UNSIGNED,
-    /**
-     * @brief   Displays absolute addresses for control flow and relative ones otherwise.
-     *
-     * Using this value will cause the formatter to invoke `ZYDIS_FORMATTER_HOOK_PRINT_ADDRESS`
-     * for every immediate target address in a control-flow instruction, but leave data accesses as
-     * relative.  This is what Intel-style disassembly typically looks like.
-     *
-     * This is the default setting.
-     */
-    ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE,
+
     /**
      * @brief   Maximum value of this enum.
      */
-    ZYDIS_ADDR_FORMAT_MAX_VALUE = ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE
+    ZYDIS_ADDR_FORMAT_MAX_VALUE = ZYDIS_ADDR_FORMAT_RELATIVE_UNSIGNED
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -437,15 +386,11 @@ enum ZydisFormatterHookTypes
      *          decorator.
      */
     ZYDIS_FORMATTER_HOOK_PRINT_DECORATOR,
-    /**
-     * @brief   This function is invoked to print the address and/or machine language opcodes 
-     *          for the instruction.
-     */
-    ZYDIS_FORMATTER_HOOK_PRINT_INSN_ADDR_BYTES,
+
     /**
      * @brief   Maximum value of this enum.
      */
-    ZYDIS_FORMATTER_HOOK_MAX_VALUE = ZYDIS_FORMATTER_HOOK_PRINT_INSN_ADDR_BYTES
+    ZYDIS_FORMATTER_HOOK_MAX_VALUE = ZYDIS_FORMATTER_HOOK_PRINT_DECORATOR
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -638,17 +583,13 @@ struct ZydisFormatter_
     ZydisU8 formatDisp;
     ZydisU8 formatImm;
     ZydisBool hexUppercase;
-    const ZydisString* hexPrefix;
+    ZydisString* hexPrefix;
     ZydisString hexPrefixData;
-    const ZydisString* hexSuffix;
+    ZydisString* hexSuffix;
     ZydisString hexSuffixData;
     ZydisU8 hexPaddingAddress;
     ZydisU8 hexPaddingDisp;
     ZydisU8 hexPaddingImm;
-    ZydisBool printBytes;
-    ZydisBool printInsnAddress;
-    ZydisU8 indentation;
-    ZydisBool padHexValues;
     ZydisFormatterFunc funcPreInstruction;
     ZydisFormatterFunc funcPostInstruction;
     ZydisFormatterOperandFunc funcPreOperand;
@@ -666,7 +607,6 @@ struct ZydisFormatter_
     ZydisFormatterOperandFunc funcPrintMemSize;
     ZydisFormatterFunc funcPrintPrefixes;
     ZydisFormatterDecoratorFunc funcPrintDecorator;
-    ZydisFormatterFunc funcPrintInsnAddrBytes;
 };
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -114,7 +114,7 @@ enum ZydisFormatterProperties
     /**
      * @brief   Controls the format of addresses.
      *
-     * The default value is `ZYDIS_ADDR_FORMAT_ABSOLUTE`.
+     * The default value is `ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE`.
      */
     ZYDIS_FORMATTER_PROP_ADDR_FORMAT,
     /**
@@ -168,11 +168,47 @@ enum ZydisFormatterProperties
      * The default value is `2`.
      */
     ZYDIS_FORMATTER_PROP_HEX_PADDING_IMM,
-
+    /**
+     * @brief   Controls whether machine language bytecodes are printed.
+     *
+     *          The bytes are printed in hexadecimal.  The ZYDIS_FORMATTER_PROP_HEX_UPPERCASE
+     *          setting is honored, but prefix, suffix and padding settings are not.
+     *          The instruction itself is printed on the next line.
+     *
+     * The default value is `ZYDIS_FALSE`.
+     */
+    ZYDIS_FORMATTER_PROP_PRINT_BYTES,
+    /**
+     * @brief   Controls whether the instruction address is printed.
+     *
+     *          The formatting options set for addresses are followed.
+     *          The instruction itself is printed on the next line.
+     *
+     * The default value is `ZYDIS_FALSE`.
+     */
+    ZYDIS_FORMATTER_PROP_PRINT_INSN_ADDR,
+    /**
+     * @brief   Controls the indentation of the printed instruction.
+     *
+     * The default value is `0`.
+     */
+    ZYDIS_FORMATTER_PROP_INDENTATION,
+    /**
+     * @brief   Controls whether hexadecimal values are padded when printed.
+     *
+     *          Padded hexadecimal values are printed with leading zeroes
+     *          to fill out the desired width (8-bit, 16-bit, etc.).
+     *          Setting this flag to `ZYDIS_FALSE` will override the
+     *          values of ZYDIS_FORMATTER_PROP_HEX_PADDING_ADDR,
+     *          ZYDIS_FORMATTER_PROP_HEX_PADDING_IMM and ZYDIS_FORMATTER_PROP_HEX_PADDING_DISP.
+     *
+     * The default value is `ZYDIS_TRUE`.
+     */
+    ZYDIS_FORMATTER_PROP_HEX_PADDING,
     /**
      * @brief   Maximum value of this enum.
      */
-    ZYDIS_FORMATTER_PROP_MAX_VALUE = ZYDIS_FORMATTER_PROP_HEX_PADDING_IMM
+    ZYDIS_FORMATTER_PROP_MAX_VALUE = ZYDIS_FORMATTER_PROP_HEX_PADDING
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -189,6 +225,8 @@ enum ZydisAddressFormat
      *
      * Using this value will cause the formatter to invoke `ZYDIS_FORMATTER_HOOK_PRINT_ADDRESS`
      * for every address.
+     *
+     * This is NOT the default setting.
      */
     ZYDIS_ADDR_FORMAT_ABSOLUTE,
     /**
@@ -200,6 +238,8 @@ enum ZydisAddressFormat
      * Examples:
      * - `"JMP  0x20"`
      * - `"JMP -0x20"`
+     *
+     * This is NOT the default setting.
      */
     ZYDIS_ADDR_FORMAT_RELATIVE_SIGNED,
     /**
@@ -211,13 +251,24 @@ enum ZydisAddressFormat
      * Examples:
      * - `"JMP 0x20"`
      * - `"JMP 0xE0"`
+     *
+     * This is NOT the default setting.
      */
     ZYDIS_ADDR_FORMAT_RELATIVE_UNSIGNED,
-
+    /**
+     * @brief   Displays absolute addresses for control flow and relative ones otherwise.
+     *
+     * Using this value will cause the formatter to invoke `ZYDIS_FORMATTER_HOOK_PRINT_ADDRESS`
+     * for every immediate target address in a control-flow instruction, but leave data accesses as
+     * relative.  This is what Intel-style disassembly typically looks like.
+     *
+     * This is the default setting.
+     */
+    ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE,
     /**
      * @brief   Maximum value of this enum.
      */
-    ZYDIS_ADDR_FORMAT_MAX_VALUE = ZYDIS_ADDR_FORMAT_RELATIVE_UNSIGNED
+    ZYDIS_ADDR_FORMAT_MAX_VALUE = ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -386,11 +437,15 @@ enum ZydisFormatterHookTypes
      *          decorator.
      */
     ZYDIS_FORMATTER_HOOK_PRINT_DECORATOR,
-
+    /**
+     * @brief   This function is invoked to print the address and/or machine language opcodes 
+     *          for the instruction.
+     */
+    ZYDIS_FORMATTER_HOOK_PRINT_INSN_ADDR_BYTES,
     /**
      * @brief   Maximum value of this enum.
      */
-    ZYDIS_FORMATTER_HOOK_MAX_VALUE = ZYDIS_FORMATTER_HOOK_PRINT_DECORATOR
+    ZYDIS_FORMATTER_HOOK_MAX_VALUE = ZYDIS_FORMATTER_HOOK_PRINT_INSN_ADDR_BYTES
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -583,13 +638,17 @@ struct ZydisFormatter_
     ZydisU8 formatDisp;
     ZydisU8 formatImm;
     ZydisBool hexUppercase;
-    ZydisString* hexPrefix;
+    const ZydisString* hexPrefix;
     ZydisString hexPrefixData;
-    ZydisString* hexSuffix;
+    const ZydisString* hexSuffix;
     ZydisString hexSuffixData;
     ZydisU8 hexPaddingAddress;
     ZydisU8 hexPaddingDisp;
     ZydisU8 hexPaddingImm;
+    ZydisBool printBytes;
+    ZydisBool printInsnAddress;
+    ZydisU8 indentation;
+    ZydisBool padHexValues;
     ZydisFormatterFunc funcPreInstruction;
     ZydisFormatterFunc funcPostInstruction;
     ZydisFormatterOperandFunc funcPreOperand;
@@ -607,6 +666,7 @@ struct ZydisFormatter_
     ZydisFormatterOperandFunc funcPrintMemSize;
     ZydisFormatterFunc funcPrintPrefixes;
     ZydisFormatterDecoratorFunc funcPrintDecorator;
+    ZydisFormatterFunc funcPrintInsnAddrBytes;
 };
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/Zydis/SharedTypes.h
+++ b/include/Zydis/SharedTypes.h
@@ -310,31 +310,31 @@ enum ZydisOperandActions
     /**
      * @brief   The operand is read by the instruction.
      */
-    ZYDIS_OPERAND_ACTION_READ,
+    ZYDIS_OPERAND_ACTION_READ = 0x01,
     /**
      * @brief   The operand is written by the instruction (must write).
      */
-    ZYDIS_OPERAND_ACTION_WRITE,
+    ZYDIS_OPERAND_ACTION_WRITE = 0x02,
     /**
      * @brief   The operand is read and written by the instruction (must write).
      */
-    ZYDIS_OPERAND_ACTION_READWRITE,
+    ZYDIS_OPERAND_ACTION_READWRITE = 0x04,
     /**
      * @brief   The operand is conditionally read by the instruction.
      */
-    ZYDIS_OPERAND_ACTION_CONDREAD,
+    ZYDIS_OPERAND_ACTION_CONDREAD = 0x08,
     /**
      * @brief   The operand is conditionally written by the instruction (may write).
      */
-    ZYDIS_OPERAND_ACTION_CONDWRITE,
+    ZYDIS_OPERAND_ACTION_CONDWRITE = 0x10,
     /**
      * @brief   The operand is read and conditionally written by the instruction (may write).
      */
-    ZYDIS_OPERAND_ACTION_READ_CONDWRITE,
+    ZYDIS_OPERAND_ACTION_READ_CONDWRITE = 0x20,
     /**
      * @brief   The operand is written and conditionally read by the instruction (must write).
      */
-    ZYDIS_OPERAND_ACTION_CONDREAD_WRITE,
+    ZYDIS_OPERAND_ACTION_CONDREAD_WRITE = 0x40,
 
     /**
      * @brief   Mask combining all writing access flags.

--- a/msvc/tools/ZydisDisasm.vcxproj
+++ b/msvc/tools/ZydisDisasm.vcxproj
@@ -152,7 +152,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -183,7 +183,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug DLL|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -214,7 +214,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -245,7 +245,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug DLL|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -276,7 +276,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -307,7 +307,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release DLL|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -338,7 +338,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -369,7 +369,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release DLL|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>

--- a/msvc/tools/ZydisDisasm.vcxproj
+++ b/msvc/tools/ZydisDisasm.vcxproj
@@ -164,7 +164,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;WIN32;_WINDOWS;_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
     </ClCompile>
     <Link>
@@ -226,7 +226,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;WIN32;_WINDOWS;_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
     </ClCompile>
     <Link>
@@ -289,6 +289,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;WIN32;_WINDOWS;NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <OmitFramePointers>true</OmitFramePointers>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -351,6 +352,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;WIN32;_WINDOWS;NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <OmitFramePointers>true</OmitFramePointers>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/msvc/tools/ZydisInfo.vcxproj
+++ b/msvc/tools/ZydisInfo.vcxproj
@@ -152,7 +152,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -183,7 +183,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug DLL|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -214,7 +214,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -245,7 +245,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug DLL|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -276,7 +276,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -307,7 +307,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release DLL|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -338,7 +338,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>
@@ -369,7 +369,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release DLL|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)/..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Gw</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>false</ExceptionHandling>

--- a/msvc/tools/ZydisInfo.vcxproj
+++ b/msvc/tools/ZydisInfo.vcxproj
@@ -164,7 +164,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;WIN32;_WINDOWS;_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
     </ClCompile>
     <Link>
@@ -226,7 +226,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;WIN32;_WINDOWS;_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
     </ClCompile>
     <Link>
@@ -289,6 +289,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;WIN32;_WINDOWS;NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <OmitFramePointers>true</OmitFramePointers>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -351,6 +352,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;WIN32;_WINDOWS;NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <OmitFramePointers>true</OmitFramePointers>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/msvc/zydis/Zydis.vcxproj
+++ b/msvc/zydis/Zydis.vcxproj
@@ -239,6 +239,7 @@
       <ExceptionHandling>false</ExceptionHandling>
       <MinimalRebuild>false</MinimalRebuild>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Lib>
       <SubSystem>Console</SubSystem>
@@ -307,6 +308,7 @@
       <StringPooling>true</StringPooling>
       <ExceptionHandling>false</ExceptionHandling>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Lib>
       <SubSystem>Console</SubSystem>
@@ -378,6 +380,7 @@
       <ExceptionHandling>false</ExceptionHandling>
       <MinimalRebuild>false</MinimalRebuild>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Lib>
       <SubSystem>Console</SubSystem>
@@ -446,6 +449,7 @@
       <StringPooling>true</StringPooling>
       <ExceptionHandling>false</ExceptionHandling>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Lib>
       <SubSystem>Console</SubSystem>

--- a/msvc/zydis/Zydis.vcxproj
+++ b/msvc/zydis/Zydis.vcxproj
@@ -58,7 +58,6 @@
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -232,7 +231,7 @@
       <AdditionalOptions>/Gw </AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <OmitDefaultLibName>true</OmitDefaultLibName>
@@ -252,7 +251,7 @@
       <PreprocessorDefinitions>ZYDIS_NO_LIBC;ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;_X86_=1;i386=1;STD_CALL;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/Gw /kernel</AdditionalOptions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <OmitDefaultLibName>true</OmitDefaultLibName>
@@ -270,7 +269,7 @@
       <AdditionalOptions>/Gw </AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>Level3</WarningLevel>
@@ -301,7 +300,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw </AdditionalOptions>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
       <WarningLevel>Level3</WarningLevel>
@@ -322,7 +321,7 @@
       <PreprocessorDefinitions>ZYDIS_NO_LIBC;ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;_X86_=1;i386=1;STD_CALL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw /kernel</AdditionalOptions>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
     </ClCompile>
@@ -340,7 +339,7 @@
       <PreprocessorDefinitions>Zydis_EXPORTS;ZYDIS_EXPORTS;_DLL;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw </AdditionalOptions>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <WarningLevel>Level3</WarningLevel>
       <StringPooling>true</StringPooling>
@@ -371,7 +370,7 @@
       <AdditionalOptions>/Gw </AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <OmitDefaultLibName>true</OmitDefaultLibName>
@@ -391,7 +390,7 @@
       <PreprocessorDefinitions>ZYDIS_NO_LIBC;ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;_WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;_AMD64_;AMD64;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/Gw /kernel</AdditionalOptions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <OmitDefaultLibName>true</OmitDefaultLibName>
@@ -409,7 +408,7 @@
       <AdditionalOptions>/Gw </AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>Level3</WarningLevel>
@@ -440,7 +439,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;_WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw </AdditionalOptions>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
       <WarningLevel>Level3</WarningLevel>
@@ -461,7 +460,7 @@
       <PreprocessorDefinitions>ZYDIS_NO_LIBC;ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;_WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw /kernel</AdditionalOptions>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
     </ClCompile>
@@ -479,7 +478,7 @@
       <PreprocessorDefinitions>Zydis_EXPORTS;ZYDIS_EXPORTS;_DLL;WIN32;_WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw </AdditionalOptions>
-      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <WarningLevel>Level3</WarningLevel>
       <StringPooling>true</StringPooling>

--- a/msvc/zydis/Zydis.vcxproj
+++ b/msvc/zydis/Zydis.vcxproj
@@ -58,6 +58,7 @@
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -231,7 +232,7 @@
       <AdditionalOptions>/Gw </AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <OmitDefaultLibName>true</OmitDefaultLibName>
@@ -251,7 +252,7 @@
       <PreprocessorDefinitions>ZYDIS_NO_LIBC;ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;_X86_=1;i386=1;STD_CALL;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/Gw /kernel</AdditionalOptions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <OmitDefaultLibName>true</OmitDefaultLibName>
@@ -269,7 +270,7 @@
       <AdditionalOptions>/Gw </AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>Level3</WarningLevel>
@@ -300,7 +301,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw </AdditionalOptions>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
       <WarningLevel>Level3</WarningLevel>
@@ -321,7 +322,7 @@
       <PreprocessorDefinitions>ZYDIS_NO_LIBC;ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;_X86_=1;i386=1;STD_CALL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw /kernel</AdditionalOptions>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
     </ClCompile>
@@ -339,7 +340,7 @@
       <PreprocessorDefinitions>Zydis_EXPORTS;ZYDIS_EXPORTS;_DLL;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw </AdditionalOptions>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <WarningLevel>Level3</WarningLevel>
       <StringPooling>true</StringPooling>
@@ -370,7 +371,7 @@
       <AdditionalOptions>/Gw </AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <OmitDefaultLibName>true</OmitDefaultLibName>
@@ -390,7 +391,7 @@
       <PreprocessorDefinitions>ZYDIS_NO_LIBC;ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;_WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;_AMD64_;AMD64;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/Gw /kernel</AdditionalOptions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <OmitDefaultLibName>true</OmitDefaultLibName>
@@ -408,7 +409,7 @@
       <AdditionalOptions>/Gw </AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>Level3</WarningLevel>
@@ -439,7 +440,7 @@
       <PreprocessorDefinitions>ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;_WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw </AdditionalOptions>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
       <WarningLevel>Level3</WarningLevel>
@@ -460,7 +461,7 @@
       <PreprocessorDefinitions>ZYDIS_NO_LIBC;ZYDIS_STATIC_DEFINE;ZYDIS_EXPORTS;_LIB;WIN32;_WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw /kernel</AdditionalOptions>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
     </ClCompile>
@@ -478,7 +479,7 @@
       <PreprocessorDefinitions>Zydis_EXPORTS;ZYDIS_EXPORTS;_DLL;WIN32;_WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <AdditionalOptions>/Gw </AdditionalOptions>
-      <AdditionalIncludeDirectories>$(ProjectDir)../../include;$(ProjectDir)../../src;$(ProjectDir)../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../include;$(SolutionDir)../src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <WarningLevel>Level3</WarningLevel>
       <StringPooling>true</StringPooling>

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -29,15 +29,6 @@
 #include <Zydis/Utils.h>
 
 /* ============================================================================================== */
-/* Constants                                                                                      */
-/* ============================================================================================== */
-
-static const ZydisString gHexPrefixDefault = ZYDIS_MAKE_STRING("0x");
-static const ZydisString gEmptyString = ZYDIS_MAKE_STRING("");
-static const ZydisString gSingleSpace = ZYDIS_MAKE_STRING(" ");
-static const ZydisString gPadding = ZYDIS_MAKE_STRING("                                        ");
-
-/* ============================================================================================== */
 /* Internal functions                                                                             */
 /* ============================================================================================== */
 
@@ -45,26 +36,9 @@ static const ZydisString gPadding = ZYDIS_MAKE_STRING("                         
 /* General                                                                                        */
 /* ---------------------------------------------------------------------------------------------- */
 
-static ZydisStatus ZydisIndent(const ZydisFormatter *formatter, ZydisString *string)
-{
-    ZydisString padding = gPadding;
-    padding.length = formatter->indentation;
-    ZYDIS_CHECK(ZydisStringAppend(string, &padding));
-    return ZYDIS_STATUS_SUCCESS;
-}
-
 static ZydisStatus ZydisFormatInstruction(const ZydisFormatter* formatter, const
     ZydisDecodedInstruction* instruction, ZydisString* string, void* userData)
 {
-    if (formatter->indentation) {
-        ZYDIS_CHECK(ZydisIndent(formatter, string));
-    }
-
-    if (formatter->printInsnAddress || formatter->printBytes)
-    {
-        ZYDIS_CHECK(formatter->funcPrintInsnAddrBytes(formatter, string, instruction, userData));
-    }
-
     if (formatter->funcPreInstruction)
     {
         ZYDIS_CHECK(formatter->funcPreInstruction(formatter, string, instruction, userData));
@@ -361,10 +335,10 @@ static ZydisStatus ZydisFormatOperandPtrIntel(const ZydisFormatter* formatter, Z
         return ZYDIS_STATUS_INVALID_PARAMETER;
     }
 
-    ZYDIS_CHECK(ZydisStringAppendHexU(string, operand->ptr.segment, formatter->padHexValues ? 4 : 0,
+    ZYDIS_CHECK(ZydisStringAppendHexU(string, operand->ptr.segment, 4,
         formatter->hexUppercase, formatter->hexPrefix, formatter->hexSuffix));
     ZYDIS_CHECK(ZydisStringAppendC(string, ":"));
-    return ZydisStringAppendHexU(string, operand->ptr.offset, formatter->padHexValues ? 8 : 0,
+    return ZydisStringAppendHexU(string, operand->ptr.offset, 8,
         formatter->hexUppercase, formatter->hexPrefix, formatter->hexSuffix);
 }
 
@@ -383,7 +357,6 @@ static ZydisStatus ZydisFormatOperandImmIntel(const ZydisFormatter* formatter, Z
         switch (formatter->formatAddress)
         {
         case ZYDIS_ADDR_FORMAT_ABSOLUTE:
-        case ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE:
         {
             ZydisU64 address;
             ZYDIS_CHECK(ZydisCalcAbsoluteAddress(instruction, operand, &address));
@@ -402,11 +375,11 @@ static ZydisStatus ZydisFormatOperandImmIntel(const ZydisFormatter* formatter, Z
         if (printSignedHEX)
         {
             return ZydisStringAppendHexS(string, (ZydisI32)operand->imm.value.s,
-                formatter->padHexValues ? formatter->hexPaddingAddress : 0, formatter->hexUppercase, formatter->hexPrefix,
+                formatter->hexPaddingAddress, formatter->hexUppercase, formatter->hexPrefix,
                 formatter->hexSuffix);
         }
         return ZydisStringAppendHexU(string, operand->imm.value.u,
-            formatter->padHexValues ? formatter->hexPaddingAddress : 0, formatter->hexUppercase, formatter->hexPrefix,
+            formatter->hexPaddingAddress, formatter->hexUppercase, formatter->hexPrefix,
             formatter->hexSuffix);
     }
 
@@ -477,13 +450,13 @@ static ZydisStatus ZydisPrintAddrIntel(const ZydisFormatter* formatter, ZydisStr
     switch (instruction->stackWidth)
     {
     case 16:
-        return ZydisStringAppendHexU(string, (ZydisU16)address, formatter->padHexValues ? 4 : 0,
+        return ZydisStringAppendHexU(string, (ZydisU16)address, 4,
             formatter->hexUppercase, formatter->hexPrefix, formatter->hexSuffix);
     case 32:
-        return ZydisStringAppendHexU(string, (ZydisU32)address, formatter->padHexValues ? 8 : 0,
+        return ZydisStringAppendHexU(string, (ZydisU32)address, 8,
             formatter->hexUppercase, formatter->hexPrefix, formatter->hexSuffix);
     case 64:
-        return ZydisStringAppendHexU(string, address, formatter->padHexValues ? 16 : 0,
+        return ZydisStringAppendHexU(string, address, 16,
             formatter->hexUppercase, formatter->hexPrefix, formatter->hexSuffix);
     default:
         return ZYDIS_STATUS_INVALID_PARAMETER;
@@ -510,7 +483,7 @@ static ZydisStatus ZydisPrintDispIntel(const ZydisFormatter* formatter, ZydisStr
             (operand->mem.base != ZYDIS_REGISTER_NONE) ||
             (operand->mem.index != ZYDIS_REGISTER_NONE)))
         {
-            return ZydisStringAppendHexS(string, operand->mem.disp.value, formatter->padHexValues? formatter->hexPaddingDisp: 0,
+            return ZydisStringAppendHexS(string, operand->mem.disp.value, formatter->hexPaddingDisp,
                 formatter->hexUppercase, formatter->hexPrefix, formatter->hexSuffix);
         }
         if ((operand->mem.base != ZYDIS_REGISTER_NONE) ||
@@ -519,7 +492,7 @@ static ZydisStatus ZydisPrintDispIntel(const ZydisFormatter* formatter, ZydisStr
             ZYDIS_CHECK(ZydisStringAppendC(string, "+"));
         }
         return ZydisStringAppendHexU(string, (ZydisU64)operand->mem.disp.value,
-            formatter->padHexValues? formatter->hexPaddingDisp: 0, formatter->hexUppercase, formatter->hexPrefix,
+            formatter->hexPaddingDisp, formatter->hexUppercase, formatter->hexPrefix,
             formatter->hexSuffix);
     }
     return ZYDIS_STATUS_SUCCESS;
@@ -547,19 +520,19 @@ static ZydisStatus ZydisPrintImmIntel(const ZydisFormatter* formatter, ZydisStri
         {
         case 8:
             return ZydisStringAppendHexS(string, (ZydisI8)operand->imm.value.s,
-                formatter->padHexValues ? formatter->hexPaddingImm : 0, formatter->hexUppercase, formatter->hexPrefix,
+                formatter->hexPaddingImm, formatter->hexUppercase, formatter->hexPrefix,
                 formatter->hexSuffix);
         case 16:
             return ZydisStringAppendHexS(string, (ZydisI16)operand->imm.value.s,
-                formatter->padHexValues ? formatter->hexPaddingImm : 0, formatter->hexUppercase, formatter->hexPrefix,
+                formatter->hexPaddingImm, formatter->hexUppercase, formatter->hexPrefix,
                 formatter->hexSuffix);
         case 32:
             return ZydisStringAppendHexS(string, (ZydisI32)operand->imm.value.s,
-                formatter->padHexValues ? formatter->hexPaddingImm : 0, formatter->hexUppercase, formatter->hexPrefix,
+                formatter->hexPaddingImm, formatter->hexUppercase, formatter->hexPrefix,
                 formatter->hexSuffix);
         case 64:
             return ZydisStringAppendHexS(string, operand->imm.value.s,
-                formatter->padHexValues ? formatter->hexPaddingImm : 0, formatter->hexUppercase, formatter->hexPrefix,
+                formatter->hexPaddingImm, formatter->hexUppercase, formatter->hexPrefix,
                 formatter->hexSuffix);
         default:
             return ZYDIS_STATUS_INVALID_PARAMETER;
@@ -569,19 +542,19 @@ static ZydisStatus ZydisPrintImmIntel(const ZydisFormatter* formatter, ZydisStri
     {
     case 8:
         return ZydisStringAppendHexU(string, (ZydisU8)operand->imm.value.u,
-            formatter->padHexValues ? formatter->hexPaddingImm : 0, formatter->hexUppercase, formatter->hexPrefix,
+            formatter->hexPaddingImm, formatter->hexUppercase, formatter->hexPrefix,
             formatter->hexSuffix);
     case 16:
         return ZydisStringAppendHexU(string, (ZydisU16)operand->imm.value.u,
-            formatter->padHexValues ? formatter->hexPaddingImm : 0, formatter->hexUppercase, formatter->hexPrefix,
+            formatter->hexPaddingImm, formatter->hexUppercase, formatter->hexPrefix,
             formatter->hexSuffix);
     case 32:
         return ZydisStringAppendHexU(string, (ZydisU32)operand->imm.value.u,
-            formatter->padHexValues ? formatter->hexPaddingImm : 0, formatter->hexUppercase, formatter->hexPrefix,
+            formatter->hexPaddingImm, formatter->hexUppercase, formatter->hexPrefix,
             formatter->hexSuffix);
     case 64:
         return ZydisStringAppendHexU(string, operand->imm.value.u,
-            formatter->padHexValues ? formatter->hexPaddingImm : 0, formatter->hexUppercase, formatter->hexPrefix,
+            formatter->hexPaddingImm, formatter->hexUppercase, formatter->hexPrefix,
             formatter->hexSuffix);
     default:
         return ZYDIS_STATUS_INVALID_PARAMETER;
@@ -604,7 +577,7 @@ static ZydisStatus ZydisPrintMemSizeIntel(const ZydisFormatter* formatter, Zydis
     if (formatter->forceMemorySize)
     {
         if ((operand->type == ZYDIS_OPERAND_TYPE_MEMORY) &&
-            (operand->mem.type == ZYDIS_MEMOP_TYPE_MEM || operand->mem.type == ZYDIS_MEMOP_TYPE_AGEN))
+            (operand->mem.type == ZYDIS_MEMOP_TYPE_MEM))
         {
             typecast = instruction->operands[operand->id].size;
         }
@@ -932,75 +905,6 @@ static ZydisStatus ZydisPrintDecoratorIntel(const ZydisFormatter* formatter, Zyd
     return ZYDIS_STATUS_SUCCESS;
 }
 
-static ZydisStatus ZydisPrintInsnAddrBytesIntel(const ZydisFormatter* formatter, ZydisString* string,
-        const ZydisDecodedInstruction* instruction, void* userData)
-{
-    ZYDIS_UNUSED_PARAMETER(userData);
-
-    if (!formatter || !instruction)
-    {
-        return ZYDIS_STATUS_INVALID_PARAMETER;
-    }
-
-    if (formatter->printInsnAddress) {
-        ZYDIS_CHECK(ZydisPrintAddrIntel(formatter, string, instruction, NULL, instruction->instrAddress, NULL));
-        ZYDIS_CHECK(ZydisStringAppendC(string, ": "));
-    }
-
-    if (formatter->printBytes) {
-        for (ZydisU8 p = 0; p < instruction->length; ++p)
-        {
-            ZYDIS_CHECK(ZydisStringAppendHexU(string, (ZydisU8)instruction->data[p],
-                formatter->padHexValues ? 2 : 0, formatter->hexUppercase, &gEmptyString, &gSingleSpace));
-        }
-    }
-
-    // The instruction itself will be printed on the next line
-    ZYDIS_CHECK(ZydisStringAppendC(string, "\n"));
-    if (formatter->indentation) {
-        ZYDIS_CHECK(ZydisIndent(formatter, string));
-    }
-    ZYDIS_CHECK(ZydisStringAppendC(string, "  "));
-
-    return ZYDIS_STATUS_SUCCESS;
-}
-
-static ZydisStatus ZydisPostInstruction(const ZydisFormatter* formatter, ZydisString* string,
-    const ZydisDecodedInstruction* instruction, void* userData)
-{
-    ZYDIS_UNUSED_PARAMETER(userData);
-
-    if (!formatter || !instruction)
-    {
-        return ZYDIS_STATUS_INVALID_PARAMETER;
-    }
-
-    if (formatter->formatAddress == ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE) {
-        // Here we print absolute values of displacements that we
-        // printed as relative earlier
-
-        for (int o = 0; o < instruction->operandCount; ++o) {
-            const ZydisDecodedOperand *operand = &instruction->operands[o];
-
-            if (operand->mem.disp.hasDisplacement && (
-                (operand->mem.base == ZYDIS_REGISTER_NONE) ||
-                (operand->mem.base == ZYDIS_REGISTER_EIP) ||
-                (operand->mem.base == ZYDIS_REGISTER_RIP)) &&
-                (operand->mem.index == ZYDIS_REGISTER_NONE) && (operand->mem.scale == 0))
-            {
-                // EIP/RIP-relative or absolute-displacement address operand
-                ZydisU64 address;
-                ZYDIS_CHECK(ZydisStringAppendC(string, "    ; "));
-                ZYDIS_CHECK(ZydisCalcAbsoluteAddress(instruction, operand, &address));
-                ZYDIS_CHECK(formatter->funcPrintAddress(formatter, string, instruction, operand,
-                    address, userData));
-            }
-        }
-    }
-
-    return ZYDIS_STATUS_SUCCESS;
-}
-
 /* ---------------------------------------------------------------------------------------------- */
 
 /* ============================================================================================== */
@@ -1014,6 +918,8 @@ ZydisStatus ZydisFormatterInit(ZydisFormatter* formatter, ZydisFormatterStyle st
         return ZYDIS_STATUS_INVALID_PARAMETER;
     }
 
+    static ZydisString hexPrefixDefault = ZYDIS_MAKE_STRING("0x");
+
     ZydisMemorySet(formatter, 0, sizeof(ZydisFormatter));
     formatter->letterCase               = ZYDIS_LETTER_CASE_DEFAULT;
     formatter->forceMemorySegment       = ZYDIS_FALSE;
@@ -1022,21 +928,17 @@ ZydisStatus ZydisFormatterInit(ZydisFormatter* formatter, ZydisFormatterStyle st
     formatter->formatDisp               = ZYDIS_DISP_FORMAT_HEX_SIGNED;
     formatter->formatImm                = ZYDIS_IMM_FORMAT_HEX_UNSIGNED;
     formatter->hexUppercase             = ZYDIS_TRUE;
-    formatter->hexPrefix                = &gHexPrefixDefault;
+    formatter->hexPrefix                = &hexPrefixDefault;
     formatter->hexSuffix                = ZYDIS_NULL;
     formatter->hexPaddingAddress        = 2;
     formatter->hexPaddingDisp           = 2;
     formatter->hexPaddingImm            = 2;
-    formatter->printBytes               = ZYDIS_FALSE;
-    formatter->printInsnAddress         = ZYDIS_FALSE;
-    formatter->indentation              = 0;
-    formatter->padHexValues             = ZYDIS_TRUE;
 
     switch (style)
     {
     case ZYDIS_FORMATTER_STYLE_INTEL:
         formatter->funcPreInstruction       = ZYDIS_NULL;
-        formatter->funcPostInstruction      = &ZydisPostInstruction;
+        formatter->funcPostInstruction      = ZYDIS_NULL;
         formatter->funcPreOperand           = ZYDIS_NULL;
         formatter->funcPostOperand          = ZYDIS_NULL;
         formatter->funcFormatInstruction    = &ZydisFormatInstrIntel;
@@ -1052,7 +954,6 @@ ZydisStatus ZydisFormatterInit(ZydisFormatter* formatter, ZydisFormatterStyle st
         formatter->funcPrintMemSize         = &ZydisPrintMemSizeIntel;
         formatter->funcPrintPrefixes        = &ZydisPrintPrefixesIntel;
         formatter->funcPrintDecorator       = &ZydisPrintDecoratorIntel;
-        formatter->funcPrintInsnAddrBytes   = &ZydisPrintInsnAddrBytesIntel;
         break;
     default:
         return ZYDIS_STATUS_INVALID_PARAMETER;
@@ -1139,22 +1040,6 @@ ZydisStatus ZydisFormatterSetProperty(ZydisFormatter* formatter,
         }
         formatter->hexPaddingImm = (ZydisU8)value;
         break;
-    case ZYDIS_FORMATTER_PROP_PRINT_BYTES:
-        formatter->printBytes = (value) ? ZYDIS_TRUE : ZYDIS_FALSE;
-        break;
-    case ZYDIS_FORMATTER_PROP_PRINT_INSN_ADDR:
-        formatter->printInsnAddress = (value) ? ZYDIS_TRUE : ZYDIS_FALSE;
-        break;
-    case ZYDIS_FORMATTER_PROP_INDENTATION:
-        if (value > gPadding.capacity)
-        {
-            return ZYDIS_STATUS_INVALID_PARAMETER;
-        }
-        formatter->indentation = (ZydisU8)value;
-        break;
-    case ZYDIS_FORMATTER_PROP_HEX_PADDING:
-        formatter->padHexValues = (value) ? ZYDIS_TRUE : ZYDIS_FALSE;
-        break;
     default:
         return ZYDIS_STATUS_INVALID_PARAMETER;
     }
@@ -1226,9 +1111,6 @@ ZydisStatus ZydisFormatterSetHook(ZydisFormatter* formatter, ZydisFormatterHookT
     case ZYDIS_FORMATTER_HOOK_PRINT_DECORATOR:
         *callback = *(const void**)&formatter->funcPrintDecorator;
         break;
-    case ZYDIS_FORMATTER_HOOK_PRINT_INSN_ADDR_BYTES:
-        *callback = *(const void**)&formatter->funcPrintInsnAddrBytes;
-        break;
     default:
         return ZYDIS_STATUS_INVALID_PARAMETER;
     }
@@ -1292,9 +1174,6 @@ ZydisStatus ZydisFormatterSetHook(ZydisFormatter* formatter, ZydisFormatterHookT
         break;
     case ZYDIS_FORMATTER_HOOK_PRINT_DECORATOR:
         formatter->funcPrintDecorator = *(ZydisFormatterDecoratorFunc*)&temp;
-        break;
-    case ZYDIS_FORMATTER_HOOK_PRINT_INSN_ADDR_BYTES:
-        formatter->funcPrintInsnAddrBytes = *(ZydisFormatterFunc*)&temp;
         break;
     default:
         return ZYDIS_STATUS_INVALID_PARAMETER;

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -274,7 +274,7 @@ static ZydisStatus ZydisFormatOperandMemIntel(const ZydisFormatter* formatter, Z
             operand->mem.segment, userData));
         break;
     case ZYDIS_REGISTER_SS:
-        if ((formatter->forceMemorySegment) ||
+        if ((formatter->forceorySegment) ||
             (instruction->attributes & ZYDIS_ATTRIB_HAS_SEGMENT_SS))
         {
             ZYDIS_CHECK(formatter->funcPrintRegister(formatter, string, instruction, operand,
@@ -282,7 +282,7 @@ static ZydisStatus ZydisFormatOperandMemIntel(const ZydisFormatter* formatter, Z
         }
         break;
     case ZYDIS_REGISTER_DS:
-        if ((formatter->forceMemorySegment) ||
+        if ((formatter->forceorySegment) ||
             (instruction->attributes & ZYDIS_ATTRIB_HAS_SEGMENT_DS))
         {
             ZYDIS_CHECK(formatter->funcPrintRegister(formatter, string, instruction, operand,
@@ -601,7 +601,7 @@ static ZydisStatus ZydisPrintMemSizeIntel(const ZydisFormatter* formatter, Zydis
     // TODO: refactor
 
     ZydisU32 typecast = 0;
-    if (formatter->forceMemorySize)
+    if (formatter->forceorySize)
     {
         if ((operand->type == ZYDIS_OPERAND_TYPE_MEMORY) &&
             (operand->mem.type == ZYDIS_MEMOP_TYPE_MEM || operand->mem.type == ZYDIS_MEMOP_TYPE_AGEN))
@@ -951,7 +951,7 @@ static ZydisStatus ZydisPrintInsnAddrBytesIntel(const ZydisFormatter* formatter,
         for (ZydisU8 p = 0; p < instruction->length; ++p)
         {
             ZYDIS_CHECK(ZydisStringAppendHexU(string, (ZydisU8)instruction->data[p],
-                formatter->padHexValues ? 2 : 0, formatter->hexUppercase, &gEmptyString, &gSingleSpace));
+                2, formatter->hexUppercase, &gEmptyString, &gSingleSpace));
         }
     }
 
@@ -1016,8 +1016,8 @@ ZydisStatus ZydisFormatterInit(ZydisFormatter* formatter, ZydisFormatterStyle st
 
     ZydisMemorySet(formatter, 0, sizeof(ZydisFormatter));
     formatter->letterCase               = ZYDIS_LETTER_CASE_DEFAULT;
-    formatter->forceMemorySegment       = ZYDIS_FALSE;
-    formatter->forceMemorySize          = ZYDIS_FALSE;
+    formatter->forceorySegment       = ZYDIS_FALSE;
+    formatter->forceorySize          = ZYDIS_FALSE;
     formatter->formatAddress            = ZYDIS_ADDR_FORMAT_ABSOLUTE;
     formatter->formatDisp               = ZYDIS_DISP_FORMAT_HEX_SIGNED;
     formatter->formatImm                = ZYDIS_IMM_FORMAT_HEX_UNSIGNED;
@@ -1075,10 +1075,10 @@ ZydisStatus ZydisFormatterSetProperty(ZydisFormatter* formatter,
         formatter->letterCase = (value) ? ZYDIS_LETTER_CASE_UPPER : ZYDIS_LETTER_CASE_DEFAULT;
         break;
     case ZYDIS_FORMATTER_PROP_FORCE_MEMSEG:
-        formatter->forceMemorySegment = (value) ? ZYDIS_TRUE : ZYDIS_FALSE;
+        formatter->forceorySegment = (value) ? ZYDIS_TRUE : ZYDIS_FALSE;
         break;
     case ZYDIS_FORMATTER_PROP_FORCE_MEMSIZE:
-        formatter->forceMemorySize = (value) ? ZYDIS_TRUE : ZYDIS_FALSE;
+        formatter->forceorySize = (value) ? ZYDIS_TRUE : ZYDIS_FALSE;
         break;
     case ZYDIS_FORMATTER_PROP_ADDR_FORMAT:
         if (value > ZYDIS_ADDR_FORMAT_MAX_VALUE)

--- a/tools/ZydisDisasm.c
+++ b/tools/ZydisDisasm.c
@@ -71,7 +71,15 @@ int main(int argc, char** argv)
         !ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
             ZYDIS_FORMATTER_PROP_FORCE_MEMSEG, ZYDIS_TRUE)) ||
         !ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
-            ZYDIS_FORMATTER_PROP_FORCE_MEMSIZE, ZYDIS_TRUE)))
+            ZYDIS_FORMATTER_PROP_FORCE_MEMSIZE, ZYDIS_TRUE)) ||
+		!ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
+			ZYDIS_FORMATTER_PROP_PRINT_BYTES, ZYDIS_TRUE)) ||
+		!ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
+			ZYDIS_FORMATTER_PROP_PRINT_INSN_ADDR, ZYDIS_TRUE)) ||
+		!ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
+			ZYDIS_FORMATTER_PROP_INDENTATION, 8)) ||
+		!ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
+			ZYDIS_FORMATTER_PROP_ADDR_FORMAT, ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE)))
     {
         fputs("Failed to initialized instruction-formatter\n", stderr);
         return EXIT_FAILURE;
@@ -85,16 +93,16 @@ int main(int argc, char** argv)
 
         ZydisDecodedInstruction instruction;
         ZydisStatus status;
-        size_t readOffs = 0;
+        size_t readOffs = 0; // This will be our instruction pointer value
         while ((status = ZydisDecoderDecodeBuffer(&decoder, readBuf + readOffs,
             numBytesRead - readOffs, readOffs, &instruction)) != ZYDIS_STATUS_NO_MORE_DATA)
         {
-            if (!ZYDIS_SUCCESS(status))
-            {
-                ++readOffs;
-                printf("db %02X\n", instruction.data[0]);
-                continue;
-            }
+            //if (!ZYDIS_SUCCESS(status))
+            //{
+            //    ++readOffs;
+            //    printf("db %02X\n", instruction.data[0]);
+            //    //continue;
+            //}
 
             char printBuffer[256];
             ZydisFormatterFormatInstruction(

--- a/tools/ZydisDisasm.c
+++ b/tools/ZydisDisasm.c
@@ -71,15 +71,7 @@ int main(int argc, char** argv)
         !ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
             ZYDIS_FORMATTER_PROP_FORCE_MEMSEG, ZYDIS_TRUE)) ||
         !ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
-            ZYDIS_FORMATTER_PROP_FORCE_MEMSIZE, ZYDIS_TRUE)) ||
-		!ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
-			ZYDIS_FORMATTER_PROP_PRINT_BYTES, ZYDIS_TRUE)) ||
-		!ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
-			ZYDIS_FORMATTER_PROP_PRINT_INSN_ADDR, ZYDIS_TRUE)) ||
-		!ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
-			ZYDIS_FORMATTER_PROP_INDENTATION, 8)) ||
-		!ZYDIS_SUCCESS(ZydisFormatterSetProperty(&formatter,
-			ZYDIS_FORMATTER_PROP_ADDR_FORMAT, ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE)))
+            ZYDIS_FORMATTER_PROP_FORCE_MEMSIZE, ZYDIS_TRUE)))
     {
         fputs("Failed to initialized instruction-formatter\n", stderr);
         return EXIT_FAILURE;
@@ -93,16 +85,16 @@ int main(int argc, char** argv)
 
         ZydisDecodedInstruction instruction;
         ZydisStatus status;
-        size_t readOffs = 0; // This will be our instruction pointer value
+        size_t readOffs = 0;
         while ((status = ZydisDecoderDecodeBuffer(&decoder, readBuf + readOffs,
             numBytesRead - readOffs, readOffs, &instruction)) != ZYDIS_STATUS_NO_MORE_DATA)
         {
-            //if (!ZYDIS_SUCCESS(status))
-            //{
-            //    ++readOffs;
-            //    printf("db %02X\n", instruction.data[0]);
-            //    //continue;
-            //}
+            if (!ZYDIS_SUCCESS(status))
+            {
+                ++readOffs;
+                printf("db %02X\n", instruction.data[0]);
+                continue;
+            }
 
             char printBuffer[256];
             ZydisFormatterFormatInstruction(


### PR DESCRIPTION
zlaski committed
6cec87e
5 changed files
Added several new formatter options to enable elegant, indented printing of instructions, their addresses and/or opcodes:
- ZYDIS_ADDR_FORMAT_JMP_ABSOLUTE
- ZYDIS_FORMATTER_PROP_PRINT_BYTES
- ZYDIS_FORMATTER_PROP_PRINT_INSN_ADDR
- ZYDIS_FORMATTER_PROP_INDENTATION
- ZYDIS_FORMATTER_PROP_HEX_PADDING

Also removed Zydis.vcxproj's dependence on $(SolutionDir) so that it may be attached to other solutions.