### PR TITLE
ZydisFormatterBasePrintDecorator: invert #if check for ZYAN_UNUSED()'s

### DIFF
--- a/src/FormatterBase.c
+++ b/src/FormatterBase.c
@@ -550,7 +550,7 @@ ZyanStatus ZydisFormatterBasePrintDecorator(const ZydisFormatter* formatter,
     ZYAN_ASSERT(buffer);
     ZYAN_ASSERT(context);
 
-#if !defined(ZYDIS_DISABLE_AVX512) && !defined(ZYDIS_DISABLE_KNC)
+#if defined(ZYDIS_DISABLE_AVX512) && defined(ZYDIS_DISABLE_KNC)
     ZYAN_UNUSED(formatter);
     ZYAN_UNUSED(buffer);
     ZYAN_UNUSED(context);


### PR DESCRIPTION
I came across this while compiling with `/WX` and testing the effects of disabling some features.

If `ZYDIS_DISABLE_AVX512` and `ZYDIS_DISABLE_KNC` are both defined, `ZYAN_UNUSED()` is needed here because otherwise the build will fail. That was probably the intent of the `#if` check, except it was testing the wrong way around.