### PR TITLE
Fix compilation when using Zydis as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ else ()
 endif ()
 
 zyan_set_common_flags("Zydis")
-target_link_libraries("Zydis" PRIVATE "Zycore")
+target_link_libraries("Zydis" PUBLIC "Zycore")
 target_include_directories("Zydis"
     PUBLIC "include" ${PROJECT_BINARY_DIR}
     PRIVATE "src")


### PR DESCRIPTION
Using Zydis in another cmake project with `add_subdirectory(Zydis)` fails for me, because the header files from `zycore` are not found, since it's not added to the include paths.

```
[1/38] Building C object CMakeFiles/my_project.dir/main.c.o
FAILED: CMakeFiles/my_project.dir/main.c.o
/usr/bin/clang  -I../zydis/include -Izydis -g -MD -MT CMakeFiles/my_project.dir/main.c.o -MF CMakeFiles/my_project.dir/main.c.o.d -o CMakeFiles/my_project.dir/main.c.o   -c ../main.c
In file included from ../main.c:3:
../zydis/include/Zydis/Zydis.h:35:10: fatal error: 'Zycore/Defines.h' file not found
#include <Zycore/Defines.h>
         ^~~~~~~~~~~~~~~~~~
1 error generated.
[10/38] Building C object zydis/CMakeFiles/Zydis.dir/src/SharedData.c.o
```
Is the full error, for reference.

This PR changes it so that the headers from zycore are visible.