### PR TITLE
Fix signed vs unsigned comparisons

### DIFF
--- a/src/MetaInfo.c
+++ b/src/MetaInfo.c
@@ -40,7 +40,7 @@
 
 const char* ZydisCategoryGetString(ZydisInstructionCategory category)
 {
-    if (category >= ZYAN_ARRAY_LENGTH(STR_INSTRUCTIONCATEGORY))
+    if ((ZyanUSize)category >= ZYAN_ARRAY_LENGTH(STR_INSTRUCTIONCATEGORY))
     {
         return ZYAN_NULL;
     }
@@ -49,7 +49,7 @@ const char* ZydisCategoryGetString(ZydisInstructionCategory category)
 
 const char* ZydisISASetGetString(ZydisISASet isa_set)
 {
-    if (isa_set >= ZYAN_ARRAY_LENGTH(STR_ISASET))
+    if ((ZyanUSize)isa_set >= ZYAN_ARRAY_LENGTH(STR_ISASET))
     {
         return ZYAN_NULL;
     }
@@ -58,7 +58,7 @@ const char* ZydisISASetGetString(ZydisISASet isa_set)
 
 const char* ZydisISAExtGetString(ZydisISAExt isa_ext)
 {
-    if (isa_ext >= ZYAN_ARRAY_LENGTH(STR_ISAEXT))
+    if ((ZyanUSize)isa_ext >= ZYAN_ARRAY_LENGTH(STR_ISAEXT))
     {
         return ZYAN_NULL;
     }

--- a/src/Mnemonic.c
+++ b/src/Mnemonic.c
@@ -33,7 +33,7 @@
 
 const char* ZydisMnemonicGetString(ZydisMnemonic mnemonic)
 {
-    if (mnemonic >= ZYAN_ARRAY_LENGTH(STR_MNEMONIC))
+    if ((ZyanUSize)mnemonic >= ZYAN_ARRAY_LENGTH(STR_MNEMONIC))
     {
         return ZYAN_NULL;
     }
@@ -42,7 +42,7 @@ const char* ZydisMnemonicGetString(ZydisMnemonic mnemonic)
 
 const ZydisShortString* ZydisMnemonicGetStringWrapped(ZydisMnemonic mnemonic)
 {
-    if (mnemonic >= ZYAN_ARRAY_LENGTH(STR_MNEMONIC))
+    if ((ZyanUSize)mnemonic >= ZYAN_ARRAY_LENGTH(STR_MNEMONIC))
     {
         return ZYAN_NULL;
     }

--- a/src/Register.c
+++ b/src/Register.c
@@ -105,7 +105,7 @@ ZydisRegister ZydisRegisterEncode(ZydisRegisterClass register_class, ZyanU8 id)
     case ZYDIS_REGCLASS_IP:
         break;
     default:
-        if ((register_class < ZYAN_ARRAY_LENGTH(REGISTER_MAP)) &&
+        if (((ZyanUSize)register_class < ZYAN_ARRAY_LENGTH(REGISTER_MAP)) &&
             (id <= (REGISTER_MAP[register_class].hi - REGISTER_MAP[register_class].lo)))
         {
             return REGISTER_MAP[register_class].lo + id;
@@ -267,7 +267,7 @@ ZydisRegister ZydisRegisterGetLargestEnclosing(ZydisMachineMode mode,
 
 const char* ZydisRegisterGetString(ZydisRegister reg)
 {
-    if (reg >= ZYAN_ARRAY_LENGTH(STR_REGISTER))
+    if ((ZyanUSize)reg >= ZYAN_ARRAY_LENGTH(STR_REGISTER))
     {
         return ZYAN_NULL;
     }
@@ -276,7 +276,7 @@ const char* ZydisRegisterGetString(ZydisRegister reg)
 
 const ZydisShortString* ZydisRegisterGetStringWrapped(ZydisRegister reg)
 {
-    if (reg >= ZYAN_ARRAY_LENGTH(STR_REGISTER))
+    if ((ZyanUSize)reg >= ZYAN_ARRAY_LENGTH(STR_REGISTER))
     {
         return ZYAN_NULL;
     }
@@ -290,7 +290,7 @@ const ZydisShortString* ZydisRegisterGetStringWrapped(ZydisRegister reg)
 ZydisRegisterWidth ZydisRegisterClassGetWidth(ZydisMachineMode mode,
     ZydisRegisterClass register_class)
 {
-    if (register_class < ZYAN_ARRAY_LENGTH(REGISTER_MAP))
+    if ((ZyanUSize)register_class < ZYAN_ARRAY_LENGTH(REGISTER_MAP))
     {
         return (mode == ZYDIS_MACHINE_MODE_LONG_64) ?
             REGISTER_MAP[register_class].width64 : REGISTER_MAP[register_class].width;

--- a/tools/ZydisInfo.c
+++ b/tools/ZydisInfo.c
@@ -606,7 +606,7 @@ static void PrintFlags(const ZydisDecodedInstruction* instruction)
 
     PrintValueLabel("ACTIONS");
     ZyanU8 c = 0;
-    for (ZydisCPUFlag i = 0; i < ZYAN_ARRAY_LENGTH(instruction->accessed_flags); ++i)
+    for (ZydisCPUFlag i = 0; (ZyanUSize)i < ZYAN_ARRAY_LENGTH(instruction->accessed_flags); ++i)
     {
         if (instruction->accessed_flags[i].action != ZYDIS_CPUFLAG_ACTION_NONE)
         {


### PR DESCRIPTION
These come from Clang's `-clang-diagnostic-sign-compare`. I doubt any actual bugs were fixed by this, but it removes a bunch of exclamation marks in my IDE.