### PR TITLE
add -fPIC option for gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ include(GNUInstallDirs)
 
 project(Zydis VERSION 3.0.0.0 LANGUAGES C CXX)
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+SET(GCC_COVERAGE_COMPILE_FLAGS "-fPIC")
+SET(GCC_COVERAGE_LINK_FLAGS    "")
+add_definitions(${GCC_COVERAGE_COMPILE_FLAGS})
+endif()
+
 # =============================================================================================== #
 # Overridable options                                                                             #
 # =============================================================================================== #


### PR DESCRIPTION
make zydis easy used in shared object