### PR TITLE
MSVC: set Windows SDK to whatever the highest available version is

### DIFF
--- a/msvc/dependencies/zycore/Zycore.vcxproj
+++ b/msvc/dependencies/zycore/Zycore.vcxproj
@@ -89,7 +89,7 @@
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug MD|Win32'" Label="Configuration">

--- a/msvc/examples/Formatter01.vcxproj
+++ b/msvc/examples/Formatter01.vcxproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B715A378-C8B9-4DC1-A57B-8BC4C47CED28}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>Formatter01</ProjectName>
   </PropertyGroup>

--- a/msvc/examples/Formatter02.vcxproj
+++ b/msvc/examples/Formatter02.vcxproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FD558EDB-A3E1-4FB5-A40A-4BE19346B24F}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>Formatter02</ProjectName>
   </PropertyGroup>

--- a/msvc/examples/Formatter03.vcxproj
+++ b/msvc/examples/Formatter03.vcxproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A67C94F3-60F8-4AAF-9309-F86F73F8529C}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>Formatter03</ProjectName>
   </PropertyGroup>

--- a/msvc/examples/ZydisPerfTest.vcxproj
+++ b/msvc/examples/ZydisPerfTest.vcxproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{91EF3E98-CD57-3870-A399-A0D98D193F80}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>ZydisPerfTest</ProjectName>
   </PropertyGroup>

--- a/msvc/examples/ZydisWinKernel.vcxproj
+++ b/msvc/examples/ZydisWinKernel.vcxproj
@@ -25,7 +25,7 @@
     <Configuration>Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc/tools/ZydisDisasm.vcxproj
+++ b/msvc/tools/ZydisDisasm.vcxproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{805CBF3F-3DDC-3141-AD7C-3B452FBEBCD2}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>ZydisDisasm</ProjectName>
   </PropertyGroup>

--- a/msvc/tools/ZydisFuzzIn.vcxproj
+++ b/msvc/tools/ZydisFuzzIn.vcxproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A0C9A331-13CC-3762-9D26-9F82C6518CAA}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>ZydisFuzzIn</ProjectName>
   </PropertyGroup>

--- a/msvc/tools/ZydisInfo.vcxproj
+++ b/msvc/tools/ZydisInfo.vcxproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BC04B6A7-D80C-3FED-97AC-BCC8370D6A7E}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>ZydisInfo</ProjectName>
   </PropertyGroup>

--- a/msvc/zydis/Zydis.vcxproj
+++ b/msvc/zydis/Zydis.vcxproj
@@ -90,7 +90,7 @@
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug MD|Win32'" Label="Configuration">


### PR DESCRIPTION
Hiya,

I had a small issue with MSVC after pulling 38df86f from upstream. I'm fine with the project changes, but VS 2017 does not recognize '10.0' as a valid SDK version, and I need to set the SDK to a specific version to get the projects to compile. As far as I know all 10.x SDKs have specific version numbers like 10.0.17763.0, but maybe '10.0' is a newly accepted value in the VS 2019 beta? Not sure. I hope so, that would mean MS is finally doing some sort of semver on these SDK releases which are never breaking anyway.

I always thought I fixed this (not historically a problem, but it is now that Windows gets a new SDK every 6 months) in my projects by setting the value of `WindowsTargetPlatformVersion` to `$(LatestTargetPlatformVersion)`, but it turns out this only works for driver projects that use the WDK. Oops.

After some digging I found this (admittedly undocumented) value that will set the SDK to whatever the highest local 10.0.X version is. This is something that CMake normally does when generating the projects. Because `/msvc` is under source control, this dumb issue causes all the project files to be in the change list for no good reason.