### PR TITLE
Fix aliasing hazard

### DIFF
--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -406,7 +406,7 @@ ZyanStatus ZydisFormatterSetHook(ZydisFormatter* formatter, ZydisFormatterFuncti
     {
         return ZYAN_STATUS_SUCCESS;
     }
-    *(ZyanUPointer*)(&formatter->func_pre_instruction + type) = *(ZyanUPointer*)&temp;
+    ZYAN_MEMCPY(&formatter->func_pre_instruction + type, &temp, sizeof(ZyanUPointer));
 
     return ZYAN_STATUS_SUCCESS;
 }


### PR DESCRIPTION
By way of background, we're trying to incorporate zydis in Firefox development builds to disassemble the code for our new wasm jit backend, see [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1539806).

We compile Firefox with -Wall -Werror=strict-aliasing in some configurations and I ran into a case in Formatter.c that breaks this.  The attatched patch fixes the problem.