### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ make
 #### Windows
 Either use the [Visual Studio 2017 project](./msvc/) or build Zydis using [CMake](https://cmake.org/download/) ([video guide](https://www.youtube.com/watch?v=fywLDK1OAtQ)).
 
+#### Building Zydis - Using vcpkg
+
+You can download and install Zydis using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+vcpkg install zydis
+```
+The Zydis port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Using Zydis in a CMake project
 An example on how to use Zydis in your own CMake based project [can be found in this repo](https://github.com/zyantific/zydis-submodule-example).
 


### PR DESCRIPTION
`Zydis` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for zydis and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build zydis, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, arm, uwp) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and[ here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/zydis/portfile.cmake). We try to keep the library maintained as close as possible to the original library.