### PR TITLE
Allow zycore dep path to be changed via CMake var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,25 +41,29 @@ option(ZYDIS_FUZZ_AFL_FAST
 option(ZYDIS_LIBFUZZER
     "Enables LLVM libfuzzer mode and reduces prints in ZydisFuzzIn"
     OFF)
+set(ZYDIS_ZYCORE_PATH
+    "${CMAKE_CURRENT_LIST_DIR}/dependencies/zycore"
+    CACHE
+    PATH
+    "The path to look for Zycore")
 
 # =============================================================================================== #
 # Dependencies                                                                                    #
 # =============================================================================================== #
 
-if (NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/dependencies/zycore/CMakeLists.txt")
+if (NOT EXISTS "${ZYDIS_ZYCORE_PATH}/CMakeLists.txt")
     message(
         FATAL_ERROR
         "Can't find zycore submodule. Please make sure to clone the repo recursively.\n"
         "You can fix this by running\n"
         "    git submodule update --init\n"
         "or by cloning using\n"
-        "    git clone --recursive <url>"
+        "    git clone --recursive <url>\n"
+        "Alternatively, you can manually clone zycore to some path and set ZYDIS_ZYCORE_PATH."
     )
 endif ()
 
-# add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../zycore-c" "${CMAKE_BINARY_DIR}/zycore"
-#     EXCLUDE_FROM_ALL)
-add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/dependencies/zycore" EXCLUDE_FROM_ALL)
+add_subdirectory(${ZYDIS_ZYCORE_PATH} "zycore" EXCLUDE_FROM_ALL)
 
 # =============================================================================================== #
 # Library configuration                                                                           #


### PR DESCRIPTION
This allows for flattening dependencies and splitting Zydis and Zycore into separate bundles in package managers. This is required to make the vcpkg people happy in regards to their wish to split Zycore/Zydis into two packages.

I'm pretty sure we had such a flag in previous versions -- do you happen to remember why we removed it? Perhaps my memory is off and this was in another project. Anyways: do you see any reason not to support that?

If you're ok with this, please just merge via rebase.