### PR TITLE
Make file list non-empty in m.css-generated docs

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -791,7 +791,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ./include \
-                         ./README.md
+                         ./README.md \
+                         ./files.dox
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/Doxyfile-mcss
+++ b/Doxyfile-mcss
@@ -4,3 +4,4 @@ GENERATE_XML            = YES
 XML_PROGRAMLISTING      = NO
 ##!M_LINKS_NAVBAR1      = modules files
 ##!M_LINKS_NAVBAR2      =
+##!M_FILE_TREE_EXPAND_LEVELS = 2

--- a/files.dox
+++ b/files.dox
@@ -1,0 +1,12 @@
+/** @dir include
+ * @brief Top-level include dir
+ */
+/** @dir include/Zydis
+ * @brief Zydis include dir
+ */
+/** @dir include/Zydis/Generated
+ * @brief Generated files
+ */
+/** @dir include/Zydis/Internal
+ * @brief Internal APIs
+ */


### PR DESCRIPTION
Original issue: https://github.com/mosra/m.css/issues/126

Makes the file list show up correctly in the docs:

![image](https://user-images.githubusercontent.com/344828/81327289-55152080-909b-11ea-8911-a801e323a014.png)

**Disclaimer:** The patch is just the minimal set of changes needed to achieve this. I didn't follow any coding guidelines and didn't know where to put the new file either (those doc blocks could be directly in the include files as well, for example). Feel free to take any of this or ignore the changes altogether :)