### PR TITLE
Fix: zydis_decoder_tree_root multiple definitions

### DIFF
--- a/include/Zydis/Internal/DecoderData.h
+++ b/include/Zydis/Internal/DecoderData.h
@@ -287,7 +287,7 @@ typedef struct ZydisInstructionEncodingInfo_
 /* Decoder tree                                                                                   */
 /* ---------------------------------------------------------------------------------------------- */
 
-const ZydisDecoderTreeNode zydis_decoder_tree_root;
+extern const ZydisDecoderTreeNode zydis_decoder_tree_root;
 
 /**
  * Returns the root node of the instruction tree.


### PR DESCRIPTION
`zydis_decoder_tree_root` is redefined in the header file, as https://github.com/zyantific/zydis/blob/99ca4c62c94201a66c2afa7dda75865d963b083e/include/Zydis/Internal/DecoderData.h#L290
while it shouldn't be.