### PR TITLE
Install zycore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (NOT EXISTS "${ZYDIS_ZYCORE_PATH}/CMakeLists.txt")
     )
 endif ()
 
-add_subdirectory(${ZYDIS_ZYCORE_PATH} "zycore" EXCLUDE_FROM_ALL)
+add_subdirectory(${ZYDIS_ZYCORE_PATH} "zycore")
 
 # =============================================================================================== #
 # Library configuration                                                                           #


### PR DESCRIPTION
If we don't install zycore, compiler will complain: 

```cpp
#include <Zydis/Zydis.h>
int main() {
}
```

```bash
# g++ -std=c++11 test_zydis.cpp -lZydis -O0 -ggdb -o test_zydis
In file included from test_zydis.cpp:1:0:
/usr/local/include/Zydis/Zydis.h:35:28: fatal error: Zycore/Defines.h: No such file or directory
 #include <Zycore/Defines.h>
                            ^
compilation terminated.
```

Test environment:

```bash
# uname -r
4.9.0-9-amd64
# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
# cmake --version
cmake version 3.7.2
# g++ --version
g++ (Debian 6.3.0-18+deb9u1) 6.3.0 20170516
```