### PR TITLE
Add unofficial Haskell binding to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Official bindings exist for a selection of languages:
 Unofficial but actively maintained bindings:
 - [Go](https://github.com/jpap/go-zydis)
 - [LuaJIT](https://github.com/Wiladams/lj2zydis)
+- [Haskell](https://github.com/nerded1337/zydiskell)
 
 ## Versions
 


### PR DESCRIPTION
Hello guys!

I am the owner of [this haskell binding](https://github.com/nerded1337/zydiskell) and would like to have it  listed despite the fact that we don't provide everything yet (only instruction decoding, no string formatting as of now).

The package will be available on [Hackage](https://hackage.haskell.org/package/zydiskell-0.1.0.1) as well.

What do you think :)?