### PR TITLE
fix invalid unsigned arithmetic.

### DIFF
--- a/examples/ZydisPerfTest.c
+++ b/examples/ZydisPerfTest.c
@@ -234,7 +234,7 @@ static ZyanU64 ProcessBuffer(const ZydisDecoder* decoder, const ZydisFormatter* 
     ZydisDecodedInstruction* instruction;
     char format_buffer[256];
 
-    while (length - offset > 0)
+    while (length > offset)
     {
         if (use_cache)
         {


### PR DESCRIPTION
your check is incorrect. since the variables are unsigned, it is equivalent to data_written != bytes_read.
so I suggest a simple fix for the error.