### PR TITLE
Print asterisk in front of absolute `jmp`/`call` address (AT&T)

### DIFF
--- a/include/Zydis/Internal/FormatterATT.h
+++ b/include/Zydis/Internal/FormatterATT.h
@@ -68,6 +68,9 @@ ZyanStatus ZydisFormatterATTPrintMnemonic(const ZydisFormatter* formatter,
 ZyanStatus ZydisFormatterATTPrintRegister(const ZydisFormatter* formatter,
     ZydisFormatterBuffer* buffer, ZydisFormatterContext* context, ZydisRegister reg);
 
+ZyanStatus ZydisFormatterATTPrintAddressABS(const ZydisFormatter* formatter,
+    ZydisFormatterBuffer* buffer, ZydisFormatterContext* context);
+
 ZyanStatus ZydisFormatterATTPrintDISP(const ZydisFormatter* formatter,
     ZydisFormatterBuffer* buffer, ZydisFormatterContext* context);
 
@@ -157,7 +160,7 @@ static const ZydisFormatter FORMATTER_ATT =
     /* func_format_operand_imm */ &ZydisFormatterBaseFormatOperandIMM,
     /* func_print_mnemonic     */ &ZydisFormatterATTPrintMnemonic,
     /* func_print_register     */ &ZydisFormatterATTPrintRegister,
-    /* func_print_address_abs  */ &ZydisFormatterBasePrintAddressABS,
+    /* func_print_address_abs  */ &ZydisFormatterATTPrintAddressABS,
     /* func_print_address_rel  */ &ZydisFormatterBasePrintAddressREL,
     /* func_print_disp         */ &ZydisFormatterATTPrintDISP,
     /* func_print_imm          */ &ZydisFormatterATTPrintIMM,

--- a/src/FormatterATT.c
+++ b/src/FormatterATT.c
@@ -354,6 +354,18 @@ ZyanStatus ZydisFormatterATTPrintRegister(const ZydisFormatter* formatter,
     return ZydisStringAppendShortCase(&buffer->string, str, formatter->case_registers);
 }
 
+ZyanStatus ZydisFormatterATTPrintAddressABS(const ZydisFormatter* formatter,
+    ZydisFormatterBuffer* buffer, ZydisFormatterContext* context)
+{
+    ZYAN_ASSERT(formatter);
+    ZYAN_ASSERT(buffer);
+    ZYAN_ASSERT(context);
+
+    ZYDIS_BUFFER_APPEND(buffer, MUL);
+
+    return ZydisFormatterBasePrintAddressABS(formatter, buffer, context);
+}
+
 ZyanStatus ZydisFormatterATTPrintDISP(const ZydisFormatter* formatter,
     ZydisFormatterBuffer* buffer, ZydisFormatterContext* context)
 {

--- a/src/FormatterATT.c
+++ b/src/FormatterATT.c
@@ -361,7 +361,11 @@ ZyanStatus ZydisFormatterATTPrintAddressABS(const ZydisFormatter* formatter,
     ZYAN_ASSERT(buffer);
     ZYAN_ASSERT(context);
 
-    ZYDIS_BUFFER_APPEND(buffer, MUL);
+    if ((context->instruction->meta.branch_type != ZYDIS_BRANCH_TYPE_NONE) &&
+        (context->instruction->operands[0].type == ZYDIS_OPERAND_TYPE_MEMORY))
+    {
+        ZYDIS_BUFFER_APPEND(buffer, MUL);
+    } 
 
     return ZydisFormatterBasePrintAddressABS(formatter, buffer, context);
 }


### PR DESCRIPTION
Fixes #176