### PR TITLE
Update MSVC project files

### DIFF
--- a/msvc/Zydis.sln
+++ b/msvc/Zydis.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.421
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{4F5048C7-CB90-437E-AB21-32258F9650B6}"
 EndProject
@@ -403,7 +403,9 @@ Global
 		{45BD58A5-1711-417F-99E7-B640C56F8009}.Release MT|X86.ActiveCfg = Release|Win32
 		{45BD58A5-1711-417F-99E7-B640C56F8009}.Release MT|X86.Deploy.0 = Release|Win32
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug Kernel|X64.ActiveCfg = Debug Kernel|x64
+		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug Kernel|X64.Build.0 = Debug Kernel|x64
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug Kernel|X86.ActiveCfg = Debug Kernel|Win32
+		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug Kernel|X86.Build.0 = Debug Kernel|Win32
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug MD DLL|X64.ActiveCfg = Debug MD DLL|x64
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug MD DLL|X64.Build.0 = Debug MD DLL|x64
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug MD DLL|X86.ActiveCfg = Debug MD DLL|Win32
@@ -421,7 +423,9 @@ Global
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug MT|X86.ActiveCfg = Debug MT|Win32
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Debug MT|X86.Build.0 = Debug MT|Win32
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Release Kernel|X64.ActiveCfg = Release Kernel|x64
+		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Release Kernel|X64.Build.0 = Release Kernel|x64
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Release Kernel|X86.ActiveCfg = Release Kernel|Win32
+		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Release Kernel|X86.Build.0 = Release Kernel|Win32
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Release MD DLL|X64.ActiveCfg = Release MD DLL|x64
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Release MD DLL|X64.Build.0 = Release MD DLL|x64
 		{E06E2E87-82B9-4DC2-A1E9-FE371CDBAAC2}.Release MD DLL|X86.ActiveCfg = Release MD DLL|Win32

--- a/msvc/dependencies/zycore/Zycore.vcxproj
+++ b/msvc/dependencies/zycore/Zycore.vcxproj
@@ -112,6 +112,8 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug MD DLL|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -145,6 +147,8 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release MD DLL|Win32'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -180,6 +184,8 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug MD DLL|x64'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -213,6 +219,8 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release MD DLL|x64'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -537,6 +545,7 @@
       <AdditionalIncludeDirectories>../../../dependencies/zycore/include;../../../dependencies/zycore;../../../dependencies/zycore/src;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Lib>
       <SubSystem>Native</SubSystem>
@@ -790,6 +799,7 @@
       <AdditionalIncludeDirectories>../../../dependencies/zycore/include;../../../dependencies/zycore;../../../dependencies/zycore/src;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Lib>
       <SubSystem>Native</SubSystem>
@@ -864,25 +874,39 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\dependencies\zycore\src\Allocator.c" />
+    <ClCompile Include="..\..\..\dependencies\zycore\src\API\Memory.c" />
+    <ClCompile Include="..\..\..\dependencies\zycore\src\API\Process.c" />
+    <ClCompile Include="..\..\..\dependencies\zycore\src\API\Synchronization.c" />
     <ClCompile Include="..\..\..\dependencies\zycore\src\API\Terminal.c" />
+    <ClCompile Include="..\..\..\dependencies\zycore\src\API\Thread.c" />
+    <ClCompile Include="..\..\..\dependencies\zycore\src\ArgParse.c" />
     <ClCompile Include="..\..\..\dependencies\zycore\src\Bitset.c" />
     <ClCompile Include="..\..\..\dependencies\zycore\src\Format.c" />
+    <ClCompile Include="..\..\..\dependencies\zycore\src\List.c" />
     <ClCompile Include="..\..\..\dependencies\zycore\src\String.c" />
     <ClCompile Include="..\..\..\dependencies\zycore\src\Vector.c" />
+    <ClCompile Include="..\..\..\dependencies\zycore\src\Zycore.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Allocator.h" />
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Memory.h" />
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Process.h" />
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Synchronization.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Terminal.h" />
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Thread.h" />
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\ArgParse.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Bitset.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Comparison.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Defines.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Format.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\LibC.h" />
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\List.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Object.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Status.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\String.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Types.h" />
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Vector.h" />
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Zycore.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\..\dependencies\zycore\resources\VersionInfo.rc" />

--- a/msvc/dependencies/zycore/Zycore.vcxproj.filters
+++ b/msvc/dependencies/zycore/Zycore.vcxproj.filters
@@ -12,6 +12,12 @@
     <Filter Include="Resource Files">
       <UniqueIdentifier>{4175306a-1bd9-42e5-9e16-98a33f23f385}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\API">
+      <UniqueIdentifier>{7784da45-08cb-44ac-bb07-f3907eb272fc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\API">
+      <UniqueIdentifier>{298b98fc-7866-4dc9-b65b-7f865143646d}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\dependencies\zycore\src\Allocator.c">
@@ -30,7 +36,28 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\dependencies\zycore\src\API\Terminal.c">
+      <Filter>Source Files\API</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\dependencies\zycore\src\API\Memory.c">
+      <Filter>Source Files\API</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\dependencies\zycore\src\API\Synchronization.c">
+      <Filter>Source Files\API</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\dependencies\zycore\src\API\Thread.c">
+      <Filter>Source Files\API</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\dependencies\zycore\src\Zycore.c">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\dependencies\zycore\src\List.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\dependencies\zycore\src\ArgParse.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\dependencies\zycore\src\API\Process.c">
+      <Filter>Source Files\API</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -67,7 +94,28 @@
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Vector.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Memory.h">
+      <Filter>Header Files\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Synchronization.h">
+      <Filter>Header Files\API</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Terminal.h">
+      <Filter>Header Files\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Thread.h">
+      <Filter>Header Files\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\Zycore.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\List.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\API\Process.h">
+      <Filter>Header Files\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\dependencies\zycore\include\Zycore\ArgParse.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msvc/examples/ZydisWinKernel.vcxproj
+++ b/msvc/examples/ZydisWinKernel.vcxproj
@@ -36,6 +36,8 @@
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <TargetVersion>Windows7</TargetVersion>
@@ -46,6 +48,8 @@
     <SupportsPackaging>false</SupportsPackaging>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <TargetVersion>Windows7</TargetVersion>
@@ -55,6 +59,8 @@
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows7</TargetVersion>
@@ -65,6 +71,8 @@
     <SupportsPackaging>false</SupportsPackaging>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -143,6 +151,7 @@
       <ControlFlowGuard>false</ControlFlowGuard>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <SupportJustMyCode>false</SupportJustMyCode>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
@@ -192,6 +201,7 @@
       <ControlFlowGuard>false</ControlFlowGuard>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <SupportJustMyCode>false</SupportJustMyCode>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>

--- a/msvc/zydis/Zydis.vcxproj
+++ b/msvc/zydis/Zydis.vcxproj
@@ -113,6 +113,8 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug MD DLL|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -146,6 +148,8 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release MD DLL|Win32'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -181,6 +185,8 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug MD DLL|x64'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -214,6 +220,8 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>WDM</DriverType>
     <SupportsPackaging>false</SupportsPackaging>
+    <SpectreMitigation>false</SpectreMitigation>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release MD DLL|x64'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -538,6 +546,7 @@
       <AdditionalIncludeDirectories>../../dependencies/zycore/include;../../include;../../src;..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Lib>
       <SubSystem>Native</SubSystem>
@@ -788,6 +797,7 @@
       <AdditionalIncludeDirectories>../../dependencies/zycore/include;../../include;../../src;..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OmitFramePointers>true</OmitFramePointers>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Lib>
       <SubSystem>Native</SubSystem>
@@ -878,17 +888,24 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Allocator.h" />
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Memory.h" />
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Process.h" />
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Synchronization.h" />
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Terminal.h" />
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Thread.h" />
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\ArgParse.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Bitset.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Comparison.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Defines.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Format.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\LibC.h" />
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\List.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Object.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Status.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\String.h" />
-    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Terminal.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Types.h" />
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Vector.h" />
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Zycore.h" />
     <ClInclude Include="..\..\include\Zydis\Decoder.h" />
     <ClInclude Include="..\..\include\Zydis\DecoderTypes.h" />
     <ClInclude Include="..\..\include\Zydis\Formatter.h" />

--- a/msvc/zydis/Zydis.vcxproj.filters
+++ b/msvc/zydis/Zydis.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="Header Files\Internal">
       <UniqueIdentifier>{CEA317BE-1F0E-40DD-A546-67659EB71E9A}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Zycore\API">
+      <UniqueIdentifier>{b6910af6-e4ae-410d-8f20-29d35667ecea}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\Decoder.c">
@@ -92,9 +95,6 @@
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\String.h">
       <Filter>Header Files\Zycore</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Terminal.h">
-      <Filter>Header Files\Zycore</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Types.h">
       <Filter>Header Files\Zycore</Filter>
     </ClInclude>
@@ -151,6 +151,30 @@
     </ClInclude>
     <ClInclude Include="..\..\include\Zydis\Internal\String.h">
       <Filter>Header Files\Internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Memory.h">
+      <Filter>Header Files\Zycore\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Synchronization.h">
+      <Filter>Header Files\Zycore\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Terminal.h">
+      <Filter>Header Files\Zycore\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Thread.h">
+      <Filter>Header Files\Zycore\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\List.h">
+      <Filter>Header Files\Zycore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\Zycore.h">
+      <Filter>Header Files\Zycore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\API\Process.h">
+      <Filter>Header Files\Zycore\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dependencies\zycore\include\Zycore\ArgParse.h">
+      <Filter>Header Files\Zycore</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR updates the MSVC project files under `msvc` to match the current source trees of Zycore and Zydis on master. There are also some fixes for minor/trivial issues I came across while doing this.

The most noticeable result of this is that, in combination with Zycore [8da0001](https://github.com/zyantific/zycore-c/commit/8da0001a1a6ddac4ddf89d0fd50186962c272829) and [d7fc85f](https://github.com/zyantific/zycore-c/commit/d7fc85fd4216abe99ad0fc3730e1e96b0d9c6a59), Windows kernel mode builds should now once again be working.

Fixes #128.