### PR TITLE
CI: test build of VS projects in `msvc` directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,45 +3,44 @@ name: GitHub Actions CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: "Build Zydis (${{ matrix.image_name }}, ${{ matrix.no_libc }})"
-    runs-on: "${{ matrix.image_name }}"
+  cmake-build-and-tests:
+    name: Build Zydis using CMake (${{ matrix.image_name }}, ${{ matrix.no_libc }})
+    runs-on: ${{ matrix.image_name }}
 
     strategy:
       matrix:
-        image_name: ["macOS-latest", "windows-2016", "ubuntu-18.04"]
-        no_libc: ["", "-DZYAN_NO_LIBC=ON"]
+        image_name: [macOS-latest, windows-2019, ubuntu-20.04]
+        no_libc: ["", -DZYAN_NO_LIBC=ON]
         include:
-        - image_name: "ubuntu-16.04"
-          no_libc: "-DCMAKE_BUILD_TYPE=Release"
-          dev_mode: "-DZYAN_DEV_MODE=ON"
+        - image_name: ubuntu-20.04
+          no_libc: -DCMAKE_BUILD_TYPE=Release
+          dev_mode: -DZYAN_DEV_MODE=ON
 
     steps:
-      - uses: "actions/checkout@v1"
-      - name: "Cloning submodules"
-        run: |
-          git submodule update --init
-      - name: "Configuring"
+      - name: Checkout
+        uses: actions/checkout@v2
+        with: { submodules: recursive }
+      - name: Configuring
         run: |
           mkdir build
           cd build
           cmake ${{ matrix.dev_mode }} ${{ matrix.no_libc }} ..
-      - name: "Building"
+      - name: Building
         run: |
           cmake --build build --config Release
-      - name: "Running regression tests"
+      - name: Running regression tests
         run: |
           cd tests
           python3 regression.py test ../build/ZydisInfo
-        if: "!matrix.no_libc && matrix.image_name != 'windows-2016'"
-      - name: "Running regression tests"
+        if: "!matrix.no_libc && matrix.image_name != 'windows-2019'"
+      - name: Running regression tests
         run: |
           cd tests
           python regression.py test ..\\build\\Release\\ZydisInfo.exe
-        if: "!matrix.no_libc && matrix.image_name == 'windows-2016'"
+        if: "!matrix.no_libc && matrix.image_name == 'windows-2019'"
 
   fuzzing:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -51,13 +50,13 @@ jobs:
         id: build
         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
         with:
-          oss-fuzz-project-name: 'zydis'
+          oss-fuzz-project-name: zydis
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
       - name: Run Fuzzers (${{ matrix.sanitizer }})
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
-          oss-fuzz-project-name: 'zydis'
+          oss-fuzz-project-name: zydis
           fuzz-seconds: 600
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   cmake-build-and-tests:
-    name: Build Zydis using CMake (${{ matrix.image_name }}, ${{ matrix.no_libc }})
+    name: CMake build + tests (${{ matrix.image_name }}, ${{ matrix.no_libc }})
     runs-on: ${{ matrix.image_name }}
 
     strategy:
@@ -38,6 +38,25 @@ jobs:
           cd tests
           python regression.py test ..\\build\\Release\\ZydisInfo.exe
         if: "!matrix.no_libc && matrix.image_name == 'windows-2019'"
+
+  msbuild-build:
+    name: MSBuild build (windows-2019)
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with: { submodules: recursive }
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.3
+        with: { vs-version: '[16.0,17)' }
+      - name: Build user-mode
+        run: |
+          cd msvc
+          msbuild.exe Zydis.sln /m /t:Rebuild '/p:Configuration="Release MD";Platform=X64'
+      - name: Build kernel-mode
+        run: |
+          cd msvc
+          msbuild.exe Zydis.sln /m /t:Rebuild '/p:Configuration="Release Kernel";Platform=X64'
 
   fuzzing:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR contains two commits.

The first is general clean-up of the CI configuration and updates all images to their latest version. I switched all images that were previously on rolling images (`xxx-latest`) to a hard-coded version. An exception to this is the macOS image, where I remember reading that using `-latest` is strongly recommended because of GH gets rid of old macOS versions very quickly (because they have to run it on Mac Minis instead of virtualized boxes).

The second commit is the actual core of this PR: it adds build targets for the VS projects in the `msvc` directory, also building the kernel mode driver.

I'm currently trying to figure out how to motivate `msbuid` to build more than just the kernel mode driver, which is proving difficult by just brute-forcing via the force-pushing to the CI. Setting up a Windows VM while writing this.

CC @Mattiwatti
