### PR TITLE
Do not sign ZydisWinKernel sample

### DIFF
--- a/msvc/examples/ZydisWinKernel.vcxproj
+++ b/msvc/examples/ZydisWinKernel.vcxproj
@@ -87,6 +87,7 @@
   <PropertyGroup />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <SignMode>Off</SignMode>
     <TimeStampServer />
     <OutDir>..\bin\DebugX86Kernel\</OutDir>
     <IntDir>obj\$(ProjectName)-$(Platform)-$(Configuration)\</IntDir>
@@ -95,6 +96,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <SignMode>Off</SignMode>
     <TimeStampServer />
     <OutDir>..\bin\ReleaseX86Kernel\</OutDir>
     <IntDir>obj\$(ProjectName)-$(Platform)-$(Configuration)\</IntDir>
@@ -103,6 +105,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <SignMode>Off</SignMode>
     <TimeStampServer />
     <OutDir>..\bin\DebugX64Kernel\</OutDir>
     <IntDir>obj\$(ProjectName)-$(Platform)-$(Configuration)\</IntDir>
@@ -111,6 +114,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <SignMode>Off</SignMode>
     <TimeStampServer />
     <OutDir>..\bin\ReleaseX64Kernel\</OutDir>
     <IntDir>obj\$(ProjectName)-$(Platform)-$(Configuration)\</IntDir>


### PR DESCRIPTION
This PR is an attempt to fix the CI build by disabling driver signing at the MSVC/MSBuild project level, as opposed to the `.vcxproj.user` files MSVC normally stores user settings in when the defaults are overridden.