### PR TITLE
Fix build on macOS 12

### DIFF
--- a/include/Zydis/ShortString.h
+++ b/include/Zydis/ShortString.h
@@ -45,7 +45,9 @@ extern "C" {
 /* Enums and types                                                                                */
 /* ============================================================================================== */
 
-#pragma pack(push, 1)
+#if !(defined(ZYAN_AARCH64) && defined(ZYAN_APPLE))
+#   pragma pack(push, 1)
+#endif
 
 /**
  * Defines the `ZydisShortString` struct.
@@ -67,7 +69,9 @@ typedef struct ZydisShortString_
     ZyanU8 size;
 } ZydisShortString;
 
-#pragma pack(pop)
+#if !(defined(ZYAN_AARCH64) && defined(ZYAN_APPLE))
+#   pragma pack(pop)
+#endif
 
 /* ============================================================================================== */
 /* Macros                                                                                         */


### PR DESCRIPTION
This PR disables struct packing for `ZydisShortString` on Apple aarch64 platforms. For an unknown reason, compilation is now failing with `ld` complaining about pointer alignment starting with macOS 12 on aarch64. On macOS 11 + aarch64, things compile perfectly fine without the change.

While we have many other packed structs, the linker seems to particularly take offense with this one, as it is the only packed struct containing a pointer. I think it might be related to some form of pointer authentication.

The binary bloat from this appears to be about 40KiB.