### PR TITLE
docs: add man pages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ option(ZYDIS_BUILD_EXAMPLES
 option(ZYDIS_BUILD_TOOLS
     "Build tools"
     ON)
+option(ZYDIS_BUILD_MAN
+    "Build manpages for the tools (requires Ronn-NG)"
+    OFF)
 option(ZYDIS_FUZZ_AFL_FAST
     "Enables AFL persistent mode and reduces prints in ZydisFuzzIn"
     OFF)
@@ -389,4 +392,24 @@ if (ZYDIS_BUILD_TOOLS AND NOT ZYAN_NO_LIBC)
         _maybe_set_emscripten_cfg("ZydisInfo")
         install(TARGETS "ZydisInfo" RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif ()
+endif ()
+
+# =============================================================================================== #
+# Manpages                                                                                        #
+# =============================================================================================== #
+
+if (ZYDIS_BUILD_MAN)
+    set(MAN_NAMES "ZydisDisasm.1" "ZydisInfo.1")
+    find_program(RONN_BIN "ronn")
+    foreach(MAN_NAME ${MAN_NAMES})
+        add_custom_command(
+            OUTPUT ${MAN_NAME}
+            COMMAND ${RONN_BIN} ARGS
+                "--roff"
+                "--output-dir=${CMAKE_CURRENT_BINARY_DIR}"
+                "${CMAKE_CURRENT_SOURCE_DIR}/man/${MAN_NAME}.ronn"
+        )
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MAN_NAME}" TYPE MAN)
+    endforeach()
+    add_custom_target(man ALL DEPENDS ${MAN_NAMES})
 endif ()

--- a/man/ZydisDisasm.1.ronn
+++ b/man/ZydisDisasm.1.ronn
@@ -1,0 +1,51 @@
+ZydisDisasm(1) -- disassemble files
+===================================
+
+## SYNOPSIS
+
+`ZydisDisasm` <machine_mode> [<input_file>]
+
+## DESCRIPTION
+
+`ZydisDisasm` allows you to decode X86 & X86-64 assembly files, dumping the disassembled instructions to stdout. With no <input_file> argument, `ZydisDisasm` will read input from stdin.
+
+## OPTIONS
+
+`ZydisDisasm` supports four different machine modes
+
+  * `-real`:
+    real machine mode
+
+  * `-16`:
+    16 bits machine mode
+
+  * `-32`:
+    32 bits machine mode
+
+  * `-64`:
+    64 bits machine mode
+
+## EXAMPLES
+
+    $ ZydisDisasm -64 input.hex
+    and byte ptr ds:[rbx], dh
+    and byte ptr ds:[r14], r14b
+    xor eax, 0x20453220
+    xor byte ptr ds:[rax], r12b
+    xor r12b, byte ptr ds:[rax]
+    xor r12d, dword ptr ds:[rax]
+    xor al, 0x38
+    and byte ptr ds:[rax], dh
+    xor dword ptr ds:[rax], esp
+    xor al, 0x20
+    cmp dword ptr ds:[rax], edi
+    and byte ptr ds:[rdx], dh
+    and byte ptr ds:[r8], sil
+    xor dword ptr ds:[rax], esp
+    xor byte ptr ds:[rax], dh
+    and byte ptr ds:[rax], dh
+    xor byte ptr ds:[rdx], cl
+
+## SEE ALSO
+
+ZydisInfo(1)

--- a/man/ZydisInfo.1.ronn
+++ b/man/ZydisInfo.1.ronn
@@ -1,0 +1,57 @@
+ZydisInfo(1) -- detailed instruction information
+================================================
+
+## SYNOPSIS
+
+`ZydisInfo` <machine_mode> [<stack_width>] <hexbytes>
+
+## DESCRIPTION
+
+`ZydisInfo` allows you to decode X86 & X86-64 assembly displaying lots of information about it.
+
+## OPTIONS
+
+`ZydisInfo` supports four different machine modes
+
+  * `-real`:
+    real machine mode
+
+  * `-16`:
+    16 bits machine mode
+
+  * `-32`:
+    32 bits machine mode
+
+  * `-64`:
+    64 bits machine mode
+
+You can also specify the stack width one of the following options
+
+  * `-16`:
+    16 bits
+
+  * `-32`:
+    32 bits
+  
+  * `-64`:
+    64 bits
+
+## EXAMPLES
+
+    $ ZydisInfo -64 66 3E 65 2E F0 F2 F3 48 01 A4 98 2C 01 00 00
+    == [    BASIC ] ==================================================
+       MNEMONIC: add [ENC: DEFAULT, MAP: DEFAULT, OPC: 0x01]
+         LENGTH: 15
+            SSZ: 64
+           EOSZ: 64
+           EASZ: 64
+       CATEGORY: BINARY
+        ISA-SET: I86
+        ISA-EXT: BASE
+     EXCEPTIONS: NONE
+     ATTRIBUTES: HAS_MODRM HAS_SIB HAS_REX CPUFLAG_ACCESS ACCEPTS_LOCK
+    [...more info...]
+
+## SEE ALSO
+
+ZydisDisasm(1)


### PR DESCRIPTION
Zydis ships two command line tools, but doesn't provide any man page. Since Debian enforces that every binary must also provide a man page here I am providing a patch.

Standard UNIX manpages are painful to write, but luckly there are tools like Ronn(-NG) or Pandoc that allow to write the page in simple Markdown and convert it in roff, the format that `man` uses.

These man pages are extremely basic, since I'm not very familiar with the tools and how they work :/
Please don't hesitate making suggestions :)

Since Ronn-NG is an extra dependency the manpages are not built by default, but only if requested with `ZYDIS_BUILD_MAN`.

Ronn-NG is required instead of the old Ronn because the latter always generates output files in the same dir as the input files, and that doesn't play nice with CMake and out of tree builds, while the -NG version has a `--output-dir` option.