### PR TITLE
Cache For Common Instructions

### DIFF
--- a/examples/Formatter01.c
+++ b/examples/Formatter01.c
@@ -159,6 +159,8 @@ int main(void)
 
     ZydisDecoder decoder;
     ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
+    // Use the common instruction cache
+    // ZydisDecoderInitializeCommonInstructionCache(&decoder);
 
     DisassembleBuffer(&decoder, &data[0], sizeof(data));
 

--- a/examples/Formatter02.c
+++ b/examples/Formatter02.c
@@ -260,6 +260,8 @@ int main(void)
 
     ZydisDecoder decoder;
     ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
+    // Use the common instruction cache
+    // ZydisDecoderInitializeCommonInstructionCache(&decoder);
 
     DisassembleBuffer(&decoder, &data[0], sizeof(data), ZYAN_FALSE);
     ZYAN_PUTS("");

--- a/examples/Formatter03.c
+++ b/examples/Formatter03.c
@@ -122,6 +122,8 @@ int main(void)
 
     ZydisDecoder decoder;
     ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
+    // Use the common instruction cache
+    // ZydisDecoderInitializeCommonInstructionCache(&decoder);
 
     DisassembleBuffer(&decoder, &data[0], sizeof(data));
 

--- a/include/Zydis/Decoder.h
+++ b/include/Zydis/Decoder.h
@@ -185,6 +185,11 @@ typedef struct ZydisDecoder_
      * The decoder mode array.
      */
     ZyanBool decoder_mode[ZYDIS_DECODER_MODE_MAX_VALUE + 1];
+    /**
+     * A pointer corresponding to the common instruction cache table
+     * for the current stack width.
+     */
+    ZydisDecodedCommonInstruction * common_instruction_cache_table;
 } ZydisDecoder;
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -315,6 +320,17 @@ ZYDIS_EXPORT ZyanStatus ZydisDecoderDecodeInstruction(const ZydisDecoder* decode
 ZYDIS_EXPORT ZyanStatus ZydisDecoderDecodeOperands(const ZydisDecoder* decoder,
     const ZydisDecoderContext* context, const ZydisDecodedInstruction* instruction,
     ZydisDecodedOperand* operands, ZyanU8 operand_count);
+
+/**
+ * Initializes a cache that contains commonly encountered instructions.
+ *
+ * @param   decoder  A pointer to the `ZydisDecoder` instance.
+ *
+ * This function must be called after the decoder is initialized.
+ *
+ * @return  A zyan status code.
+ */
+ZYDIS_EXPORT ZyanStatus ZydisDecoderInitializeCommonInstructionCache(const ZydisDecoder* decoder);
 
 /** @} */
 


### PR DESCRIPTION
The use of the common instruction cache yields an average speed increase of 15% to 20% on my computer. It does, however, slightly reduce the speed if it is not used as it has to check if the cache is being used, so perhaps this could be either enabled/disabled through a #define or have it be enabled by default. It could probably be further optimized for even greater speeds. It is very simple to enable for a single instance of a ZydisDecoder, and I have included commented out calls to the initialization in the Formatter examples.