### PR TITLE
Prevent duplicate CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: GitHub Actions CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   cmake-build-and-tests:


### PR DESCRIPTION
Pull requests created from internal branches would previously execute all CI steps twice. This PR resolves that.