### PR TITLE
Encoder: improve `ZydisArePrefixesCompatible` perf

### DIFF
--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -2762,6 +2762,12 @@ static ZyanBool ZydisIsDefinitionCompatible(ZydisEncoderInstructionMatch *match,
  */
 static ZyanBool ZydisArePrefixesCompatible(const ZydisEncoderInstructionMatch *match)
 {
+    // Early-exit optimization for when no prefixes are requested at all.
+    if (!(match->attributes & ZYDIS_ENCODABLE_PREFIXES))
+    {
+        return ZYAN_TRUE;
+    }
+
     if ((!match->base_definition->accepts_segment) &&
         (match->attributes & ZYDIS_ATTRIB_HAS_SEGMENT))
     {


### PR DESCRIPTION
Most instructions tend to not have any custom prefixes, so it greatly improves overall encoder performance when we check if any prefix is requested at all and potentially early-exit before doing a detailed check.

In a small benchmark, this improved overall encoder performance by about 10%.

CC @mappzor 