### PR TITLE
Avoid passing variable size to memcpy to prevent external call

### DIFF
--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -3132,6 +3132,8 @@ static ZyanStatus ZydisEmitUInt(ZyanU64 data, ZyanU8 size, ZydisEncoderBuffer *b
     }
 
     // TODO: fix for big-endian systems
+    // The size variable is not passed on purpose to allow the compiler
+    // to generate better code with a known size at compile time.
     if (size == 1)
     {
         ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 1);
@@ -3147,6 +3149,10 @@ static ZyanStatus ZydisEmitUInt(ZyanU64 data, ZyanU8 size, ZydisEncoderBuffer *b
     else if (size == 8)
     {
         ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 8);
+    }
+    else
+    {
+        ZYAN_UNREACHABLE;
     }
 
     buffer->offset = new_offset;

--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -3132,7 +3132,22 @@ static ZyanStatus ZydisEmitUInt(ZyanU64 data, ZyanU8 size, ZydisEncoderBuffer *b
     }
 
     // TODO: fix for big-endian systems
-    ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, size);
+    if (size == 1)
+    {
+        ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 1);
+    }
+    else if (size == 2)
+    {
+        ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 2);
+    }
+    else if (size == 4)
+    {
+        ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 4);
+    }
+    else if (size == 8)
+    {
+        ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 8);
+    }
 
     buffer->offset = new_offset;
     return ZYAN_STATUS_SUCCESS;


### PR DESCRIPTION
I've compiled the code with MSVC and Clang 12 in both cases they had a call to memcpy, I don't know what GCC would do as I'm on Windows, but since Clang and MSVC see an improvement I think its worth it.

There is a noticeable improvement using the benchmarks in Zasm.

master:
```
BM_Serialization/4096                    1.73 ms         2.04 ms          345 BytesEncoded=13.3207M/s Instructions=2.00977M/s
BM_Serialization/8192                    3.84 ms         3.59 ms          187 BytesEncoded=16.1648M/s Instructions=2.28004M/s
BM_Serialization/16384                   7.89 ms         8.16 ms           90 BytesEncoded=14.2344M/s Instructions=2.00791M/s
BM_Serialization/32768                   15.9 ms         16.0 ms           45 BytesEncoded=14.5135M/s Instructions=2.05156M/s
BM_Serialization/65536                   31.8 ms         30.5 ms           22 BytesEncoded=15.3129M/s Instructions=2.14592M/s
BM_Serialization/131072                  63.2 ms         63.9 ms           11 BytesEncoded=14.686M/s Instructions=2.05055M/s
BM_Serialization/262144                   126 ms          128 ms            6 BytesEncoded=14.7109M/s Instructions=2.05435M/s
BM_Serialization/524288                   254 ms          255 ms            3 BytesEncoded=14.7103M/s Instructions=2.05435M/s
BM_Serialization/1048576                  509 ms          516 ms            1 BytesEncoded=14.5616M/s Instructions=2.0336M/s
BM_Serialization/2097152                 1017 ms         1016 ms            1 BytesEncoded=14.7856M/s Instructions=2.06489M/s
```
PR (Clang):
```
BM_Serialization/4096                    1.53 ms         1.79 ms          280 BytesEncoded=15.203M/s Instructions=2.29376M/s
BM_Serialization/8192                    3.33 ms         3.23 ms          213 BytesEncoded=17.9939M/s Instructions=2.53803M/s
BM_Serialization/16384                   6.86 ms         6.56 ms          112 BytesEncoded=17.714M/s Instructions=2.49873M/s
BM_Serialization/32768                   13.7 ms         13.1 ms           50 BytesEncoded=17.662M/s Instructions=2.49661M/s
BM_Serialization/65536                   27.7 ms         28.8 ms           25 BytesEncoded=16.2661M/s Instructions=2.27951M/s
BM_Serialization/131072                  56.3 ms         56.8 ms           11 BytesEncoded=16.5217M/s Instructions=2.30687M/s
BM_Serialization/262144                   113 ms          115 ms            6 BytesEncoded=16.3826M/s Instructions=2.2878M/s
BM_Serialization/524288                   227 ms          224 ms            3 BytesEncoded=16.7629M/s Instructions=2.34101M/s
BM_Serialization/1048576                  449 ms          445 ms            2 BytesEncoded=16.8608M/s Instructions=2.3547M/s
BM_Serialization/2097152                  899 ms          906 ms            1 BytesEncoded=16.57M/s Instructions=2.3141M/s
```
PR (MSVC):
```
BM_Serialization/4096                    1.38 ms         1.46 ms          512 BytesEncoded=18.5332M/s Instructions=2.7962M/s
BM_Serialization/8192                    2.99 ms         2.95 ms          249 BytesEncoded=19.6924M/s Instructions=2.77761M/s
BM_Serialization/16384                   6.13 ms         5.94 ms          100 BytesEncoded=19.5619M/s Instructions=2.75941M/s
BM_Serialization/32768                   12.2 ms         12.6 ms           56 BytesEncoded=18.4627M/s Instructions=2.60979M/s
BM_Serialization/65536                   25.1 ms         25.5 ms           30 BytesEncoded=18.3243M/s Instructions=2.56794M/s
BM_Serialization/131072                  50.3 ms         51.6 ms           10 BytesEncoded=18.2057M/s Instructions=2.542M/s
BM_Serialization/262144                   101 ms          105 ms            7 BytesEncoded=17.8931M/s Instructions=2.49873M/s
BM_Serialization/524288                   204 ms          208 ms            3 BytesEncoded=18.0202M/s Instructions=2.51658M/s
BM_Serialization/1048576                  410 ms          414 ms            2 BytesEncoded=18.1333M/s Instructions=2.53241M/s
BM_Serialization/2097152                  816 ms          812 ms            1 BytesEncoded=18.4819M/s Instructions=2.58111M/s
```
I also looked at the compiled output, Clang seems to turn this into a jump table, I rather wish it didn't do that, MSVC uses basic branching which probably explains the difference.