### PR TITLE
Extend porting guide

### DIFF
--- a/assets/porting-guide-v3-v4.md
+++ b/assets/porting-guide-v3-v4.md
@@ -1,69 +1,65 @@
 # Porting Guide v3 -> v4
 
-- Zydis now requires a C11 capable compiler
-
-## API changes
-
-### ZydisDecodedInstruction
-
-1. Removed field `operands`
-   - The `operands` array is passed to the desired decoder function as a separate argument instead
-2. Added field `operand_count_visible`
-   - Contains the number of visible (explicit and implicit) operands
-
-### Decoder
-
-#### 1
-
-Removed:
-
-```c
-ZYDIS_EXPORT ZyanStatus ZydisDecoderDecodeBuffer(const ZydisDecoder* decoder,
-    const void* buffer, ZyanUSize length, ZydisDecodedInstruction* instruction);
-```
-
-Replaced by:
-
-```c
-ZYDIS_EXPORT ZyanStatus ZydisDecoderDecodeFull(const ZydisDecoder* decoder,
-    const void* buffer, ZyanUSize length, ZydisDecodedInstruction* instruction,
-    ZydisDecodedOperand* operands, ZyanU8 operand_count, ZydisDecodingFlags flags);
-```
-
-#### 2
-
-Added:
-
-```c
-ZYDIS_EXPORT ZyanStatus ZydisDecoderDecodeInstruction(const ZydisDecoder* decoder,
-    ZydisDecoderContext* context, const void* buffer, ZyanUSize length,
-    ZydisDecodedInstruction* instruction);
-```
-
-Added:
-
-```c
-ZYDIS_EXPORT ZyanStatus ZydisDecoderDecodeOperands(const ZydisDecoder* decoder,
-    const ZydisDecoderContext* context, const ZydisDecodedInstruction* instruction,
-    ZydisDecodedOperand* operands, ZyanU8 operand_count);
-```
-
 ### General
 
+- Zydis now requires a C11 capable compiler
 - Type renamed: `ZydisAddressWidth` -> `ZydisStackWidth`
-  - Constants renamed: `ZYDIS_ADDRESS_WIDTH_XXX` -> `ZYDIS_STACK_WIDTH_XXX`
 - Enum changed: `ZydisMemoryOperandType`
   - Constants added: `ZYDIS_MEMOP_TYPE_VSIB`
 - Decoding behavior changed:
-  - In case of vector SIB addressing memory operands, `ZYDIS_MEMOP_TYPE_VSIB` will be reported by the decoder instead of `ZYDIS_MEMOP_TYPE_MEM` (in `ZydisDecodedOperand.mem.type`)
+  - In case of vector SIB addressing memory operands, `ZYDIS_MEMOP_TYPE_VSIB` will be reported by the decoder instead
+    of `ZYDIS_MEMOP_TYPE_MEM` (in `ZydisDecodedOperand.mem.type`)
 - Constants renamed:
   - `ZYDIS_STATIC_DEFINE` -> `ZYDIS_STATIC_BUILD`
   - `Zydis_EXPORTS` -> `ZYDIS_SHOULD_EXPORT`
+  - `ZYDIS_ADDRESS_WIDTH_XXX` -> `ZYDIS_STACK_WIDTH_XXX`
+- `ZydisCPUFlagAction` got replaced by `ZydisAccessedFlagsMask`
+- `ZydisAccessedFlags` was added as a replacement for the CPU flag arrays
+- `ZYDIS_CPUFLAG_C[0-3]` were replaced with `ZYDIS_FPUFLAG_C[0-3]`
 
-## Changes relevant for language bindings
+### Decoder
 
+- Added functions to decode instructions and operands individually, allowing for improved performance when the operands
+  are not actually needed.
+  - `ZydisDecoderDecodeInstruction`
+  - `ZydisDecoderDecodeOperands`
+- `ZydisDecoderDecodeBuffer` got replaced by `ZydisDecoderDecodeFull`
+- `ZydisDecodedInstruction` struct was changed
+  - Removed field `operands`
+     - The `operands` array is passed to the desired decoder function as a separate argument instead
+  - Added field `operand_count_visible`
+     - Contains the number of visible (explicit and implicit) operands
+  - The `cpu_flags_read` and `cpu_flags_written` fields are replaced with the `cpu_flags` field
+  - The `fpu_flags_read` and `fpu_flags_read` fields are replaced with the `fpu_flags` field
+  - The older `accessed_flags` array is replaced by the `cpu_flags` and `fpu_flags` fields
+
+### Formatter
+
+- Added arguments to accommodate the new decoder API changes
+  - The signature of `ZydisFormatterFormatInstruction(Ex)?` changed
+  - The signature of `ZydisFormatterFormatOperand(Ex)?` changed
+  - The signature of `ZydisFormatterTokenizeInstruction(Ex)?` changed
+  - The signature of `ZydisFormatterTokenizeOperand(Ex)?` changed
+
+### Utils
+
+- Removed flag helpers (no longer needed with new flags format!)
+  - `ZydisGetAccessedFlagsByAction`
+  - `ZydisGetAccessedFlagsRead`
+  - `ZydisGetAccessedFlagsWritten`
+
+### Changes relevant for language bindings
+
+- Encoder added
+  - `Encoder.h`, various new types and functions
+- Type `ZydisRegisterKind` added
 - The `ZYDIS_ATTRIB_` defines were rebased (underlying bits were changed)
-- New type: `ZydisDecodingFlags`
-- New type: `ZydisDecoderContext`
+- New type `ZydisDecodingFlags`
+- New type `ZydisDecoderContext`
+- An anonymous union was added around some fields in the `raw` part of `ZydisDecodedInstruction`
+- An anonymous union was added around the operand type specific fields in `ZydisDecodedOperand`
+- The previously anonymous sub-structs in `ZydisDecodedOperand` were lifted to 
+  the top level scope and are proper types now
+- Some of the previously anonymous sub-structs in `ZydisDecodedInstruction` were lifted to the top level scope as well
 - `ZydisDecodedOperand::type` was moved to a different location in the struct
 - Unions were added around fields in `ZydisDecodedOperand` and `ZydisDecodedInstruction`


### PR DESCRIPTION
In light of the v4.0 release drawing closer, I took some time to refine our porting guide, putting in everything that I remember and also doing a quick sweep through the git-blame, looking for recent changes. 