### PR TITLE
Duplicate encoding to aid Rust bindings

### DIFF
--- a/include/Zydis/DecoderTypes.h
+++ b/include/Zydis/DecoderTypes.h
@@ -1143,6 +1143,13 @@ typedef struct ZydisDecodedInstruction_
         } rex;
 
         /*
+         * Copy of the `encoding` field.
+         *
+         * This is here to allow the Rust bindings to treat the following union as an `enum`,
+         * sparing us a lot of unsafe code. Prefer using the regular `encoding` field in C/C++ code.
+         */
+        ZydisInstructionEncoding encoding2;
+        /*
          * Union for things from various mutually exclusive vector extensions.
          */
         union {
@@ -1151,6 +1158,7 @@ typedef struct ZydisDecodedInstruction_
             ZydisDecodedInstructionRawEvex evex;
             ZydisDecodedInstructionRawMvex mvex;
         };
+
         /**
          * Detailed info about the `ModRM` byte.
          */

--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -5037,6 +5037,8 @@ ZyanStatus ZydisDecoderDecodeInstruction(const ZydisDecoder* decoder, ZydisDecod
     ZYAN_CHECK(ZydisCollectOptionalPrefixes(&state, instruction));
     ZYAN_CHECK(ZydisDecodeInstruction(&state, instruction));
 
+    instruction->raw.encoding2 = instruction->encoding;
+
     return ZYAN_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
As previously discussed in Discord, this PR duplicates the encoding field in the `raw` section of the decoded instruction to allow the Rust bindings to model it as a safe enum.