### PR TITLE
Simplify formatter interface

### DIFF
--- a/assets/porting-guide-v3-v4.md
+++ b/assets/porting-guide-v3-v4.md
@@ -47,7 +47,9 @@
   - The signature of `ZydisFormatterTokenizeInstruction` changed
   - The functionality of `ZydisFormatterTokenizeInstructionEx` was integrated into the non-`Ex`
     variant of the function
-  - The signature of `ZydisFormatterTokenizeOperand(Ex)?` changed
+  - The signature of `ZydisFormatterTokenizeOperand` changed
+  - The functionality of `ZydisFormatterTokenizeOperandEx` was integrated into the non-`Ex`
+    variant of the function
 
 ### Utils
 

--- a/assets/porting-guide-v3-v4.md
+++ b/assets/porting-guide-v3-v4.md
@@ -38,8 +38,12 @@
 ### Formatter
 
 - Added arguments to accommodate the new decoder API changes
-  - The signature of `ZydisFormatterFormatInstruction(Ex)?` changed
-  - The signature of `ZydisFormatterFormatOperand(Ex)?` changed
+  - The signature of `ZydisFormatterFormatInstruction` changed
+  - The functionality of `ZydisFormatterFormatInstructionEx` was integrated into the non-`Ex`
+    variant of the function
+  - The signature of `ZydisFormatterFormatOperand` changed
+  - The functionality of `ZydisFormatterFormatOperandEx` was integrated into the non-`Ex`
+    variant of the function
   - The signature of `ZydisFormatterTokenizeInstruction(Ex)?` changed
   - The signature of `ZydisFormatterTokenizeOperand(Ex)?` changed
 

--- a/assets/porting-guide-v3-v4.md
+++ b/assets/porting-guide-v3-v4.md
@@ -44,7 +44,9 @@
   - The signature of `ZydisFormatterFormatOperand` changed
   - The functionality of `ZydisFormatterFormatOperandEx` was integrated into the non-`Ex`
     variant of the function
-  - The signature of `ZydisFormatterTokenizeInstruction(Ex)?` changed
+  - The signature of `ZydisFormatterTokenizeInstruction` changed
+  - The functionality of `ZydisFormatterTokenizeInstructionEx` was integrated into the non-`Ex`
+    variant of the function
   - The signature of `ZydisFormatterTokenizeOperand(Ex)?` changed
 
 ### Utils

--- a/assets/porting-guide-v3-v4.md
+++ b/assets/porting-guide-v3-v4.md
@@ -38,18 +38,13 @@
 ### Formatter
 
 - Added arguments to accommodate the new decoder API changes
-  - The signature of `ZydisFormatterFormatInstruction` changed
-  - The functionality of `ZydisFormatterFormatInstructionEx` was integrated into the non-`Ex`
-    variant of the function
-  - The signature of `ZydisFormatterFormatOperand` changed
-  - The functionality of `ZydisFormatterFormatOperandEx` was integrated into the non-`Ex`
-    variant of the function
-  - The signature of `ZydisFormatterTokenizeInstruction` changed
-  - The functionality of `ZydisFormatterTokenizeInstructionEx` was integrated into the non-`Ex`
-    variant of the function
-  - The signature of `ZydisFormatterTokenizeOperand` changed
-  - The functionality of `ZydisFormatterTokenizeOperandEx` was integrated into the non-`Ex`
-    variant of the function
+- Arguments from `Ex` variants of various functions were integrated into the non-`Ex` variant
+  - All of these varied by only a single argument and didn't warrant the additional complexity 
+- As a result, the signature of the following functions changed:
+  - `ZydisFormatterFormatInstruction`
+  - `ZydisFormatterFormatOperand`
+  - `ZydisFormatterTokenizeInstruction`
+  - `ZydisFormatterTokenizeOperand`
 
 ### Utils
 

--- a/examples/Formatter01.c
+++ b/examples/Formatter01.c
@@ -126,7 +126,8 @@ static void DisassembleBuffer(ZydisDecoder* decoder, ZyanU8* data, ZyanUSize len
         // We have to pass a `runtime_address` different to `ZYDIS_RUNTIME_ADDRESS_NONE` to
         // enable printing of absolute addresses
         ZydisFormatterFormatInstruction(&formatter, &instruction, operands,
-            instruction.operand_count_visible, &buffer[0], sizeof(buffer), runtime_address);
+            instruction.operand_count_visible, &buffer[0], sizeof(buffer), runtime_address,
+            ZYAN_NULL);
         ZYAN_PRINTF(" %s\n", &buffer[0]);
 
         data += instruction.length;

--- a/examples/Formatter02.c
+++ b/examples/Formatter02.c
@@ -220,7 +220,7 @@ static void DisassembleBuffer(ZydisDecoder* decoder, ZyanU8* data, ZyanUSize len
     {
         ZYAN_PRINTF("%016" PRIX64 "  ", runtime_address);
 
-        ZydisFormatterFormatInstructionEx(&formatter, &instruction, operands,
+        ZydisFormatterFormatInstruction(&formatter, &instruction, operands,
             instruction.operand_count_visible, &buffer[0], sizeof(buffer), runtime_address,
             &user_data);
         ZYAN_PRINTF(" %s\n", &buffer[0]);

--- a/examples/Formatter03.c
+++ b/examples/Formatter03.c
@@ -80,7 +80,7 @@ static void DisassembleBuffer(ZydisDecoder* decoder, ZyanU8* data, ZyanUSize len
         const ZydisFormatterToken* token;
         if (ZYAN_SUCCESS(ZydisFormatterTokenizeInstruction(&formatter, &instruction, operands,
             instruction.operand_count_visible , &buffer[0], sizeof(buffer), runtime_address,
-            &token)))
+            &token, ZYAN_NULL)))
         {
             ZydisTokenType token_type;
             ZyanConstCharPointer token_value = ZYAN_NULL;

--- a/examples/RewriteCode.c
+++ b/examples/RewriteCode.c
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
     // Format & print the original instruction.
     char fmt_buf[256];
     ExpectSuccess(ZydisFormatterFormatInstruction(&fmt, &instr, operands,
-        instr.operand_count_visible, fmt_buf, sizeof(fmt_buf), 0));
+        instr.operand_count_visible, fmt_buf, sizeof(fmt_buf), 0, NULL));
     printf("Original instruction: %s\n", fmt_buf);
 
     // Create an encoder request from the previously decoded instruction.
@@ -159,7 +159,7 @@ int main(int argc, char** argv)
     ExpectSuccess(ZydisDecoderDecodeFull(&decoder, new_bytes, new_instr_length, &instr,
         operands, ZYDIS_MAX_OPERAND_COUNT_VISIBLE, ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY));
     ExpectSuccess(ZydisFormatterFormatInstruction(&fmt, &instr, operands,
-        instr.operand_count_visible, fmt_buf, sizeof(fmt_buf), 0));
+        instr.operand_count_visible, fmt_buf, sizeof(fmt_buf), 0, NULL));
     printf("New instruction:      %s\n", fmt_buf);
 
     // Print the new instruction as hex-bytes.

--- a/examples/ZydisPerfTest.c
+++ b/examples/ZydisPerfTest.c
@@ -276,7 +276,8 @@ static ZyanU64 ProcessBuffer(const ZydisDecoder* decoder, const ZydisFormatter* 
                 const ZydisFormatterToken* token;
                 ZydisFormatterTokenizeInstruction(formatter, &context->instruction,
                     context->operands, context->instruction.operand_count_visible, 
-                    context->format_buffer, sizeof(context->format_buffer), offset, &token);
+                    context->format_buffer, sizeof(context->format_buffer), offset, &token,
+                    ZYAN_NULL);
             } else
             {
                 ZydisFormatterFormatInstruction(formatter, &context->instruction,

--- a/examples/ZydisPerfTest.c
+++ b/examples/ZydisPerfTest.c
@@ -281,7 +281,7 @@ static ZyanU64 ProcessBuffer(const ZydisDecoder* decoder, const ZydisFormatter* 
             {
                 ZydisFormatterFormatInstruction(formatter, &context->instruction,
                     context->operands, context->instruction.operand_count_visible, 
-                    context->format_buffer, sizeof(context->format_buffer), offset);
+                    context->format_buffer, sizeof(context->format_buffer), offset, ZYAN_NULL);
             }
         }
 

--- a/examples/ZydisWinKernel.c
+++ b/examples/ZydisWinKernel.c
@@ -180,7 +180,7 @@ DriverEntry(
         const ZyanU64 instrAddress = (ZyanU64)(imageBase + entryPointRva + readOffset);
         ZydisFormatterFormatInstruction(
             &formatter, &instruction, operands, instruction.operand_count_visible, printBuffer, 
-            sizeof(printBuffer), instrAddress);
+            sizeof(printBuffer), instrAddress, NULL);
         Print("+%-4X 0x%-16llX\t\t%hs\n", (ULONG)readOffset, instrAddress, printBuffer);
 
         readOffset += instruction.length;

--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -1047,7 +1047,7 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterSetHook(ZydisFormatter* formatter,
  * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
  *                          to print relative addresses.
  * @param   user_data       A pointer to user-defined data which can be used in custom formatter
- *                          callbacks.
+ *                          callbacks. Can be `ZYAN_NULL`.
  *
  * @return  A zyan status code.
  */
@@ -1067,7 +1067,7 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatInstruction(const ZydisFormatter* fo
  * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
  *                          to print relative addresses.
  * @param   user_data       A pointer to user-defined data which can be used in custom formatter
- *                          callbacks.
+ *                          callbacks. Can be `ZYAN_NULL`.
  *
  * @return  A zyan status code.
  *
@@ -1097,7 +1097,7 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatOperand(const ZydisFormatter* format
  *                          to print relative addresses.
  * @param   token           Receives a pointer to the first token in the output buffer.
  * @param   user_data       A pointer to user-defined data which can be used in custom formatter
- *                          callbacks.
+ *                          callbacks. Can be `ZYAN_NULL`.
  *
  * @return  A zyan status code.
  */
@@ -1118,7 +1118,7 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterTokenizeInstruction(const ZydisFormatter* 
  *                          to print relative addresses.
  * @param   token           Receives a pointer to the first token in the output buffer.
  * @param   user_data       A pointer to user-defined data which can be used in custom formatter
- *                          callbacks.
+ *                          callbacks. Can be `ZYAN_NULL`.
  *
  * @return  A zyan status code.
  *

--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -1066,26 +1066,6 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatInstruction(const ZydisFormatter* fo
  * @param   length          The length of the output buffer (in characters).
  * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
  *                          to print relative addresses.
- *
- * @return  A zyan status code.
- *
- * Use `ZydisFormatterFormatInstruction` or `ZydisFormatterFormatInstructionEx` to format a
- * complete instruction.
- */
-ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatOperand(const ZydisFormatter* formatter,
-    const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operand,
-    char* buffer, ZyanUSize length, ZyanU64 runtime_address);
-
-/**
- * Formats the given operand and writes it into the output buffer.
- *
- * @param   formatter       A pointer to the `ZydisFormatter` instance.
- * @param   instruction     A pointer to the `ZydisDecodedInstruction` struct.
- * @param   operand         A pointer to the `ZydisDecodedOperand` struct of the operand to format.
- * @param   buffer          A pointer to the output buffer.
- * @param   length          The length of the output buffer (in characters).
- * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
- *                          to print relative addresses.
  * @param   user_data       A pointer to user-defined data which can be used in custom formatter
  *                          callbacks.
  *
@@ -1094,7 +1074,7 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatOperand(const ZydisFormatter* format
  * Use `ZydisFormatterFormatInstruction` or `ZydisFormatterFormatInstructionEx` to format a
  * complete instruction.
  */
-ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatOperandEx(const ZydisFormatter* formatter,
+ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatOperand(const ZydisFormatter* formatter,
     const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operand,
     char* buffer, ZyanUSize length, ZyanU64 runtime_address, void* user_data);
 

--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -1096,34 +1096,12 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatOperand(const ZydisFormatter* format
  * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
  *                          to print relative addresses.
  * @param   token           Receives a pointer to the first token in the output buffer.
- *
- * @return  A zyan status code.
- */
-ZYDIS_EXPORT ZyanStatus ZydisFormatterTokenizeInstruction(const ZydisFormatter* formatter,
-    const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operands,
-    ZyanU8 operand_count, void* buffer, ZyanUSize length, ZyanU64 runtime_address,
-    ZydisFormatterTokenConst** token);
-
-/**
- * Tokenizes the given instruction and writes it into the output buffer.
- *
- * @param   formatter       A pointer to the `ZydisFormatter` instance.
- * @param   instruction     A pointer to the `ZydisDecodedInstruction` struct.
- * @param   operands        A pointer to the decoded operands array.
- * @param   operand_count   The number of operands to format and read from the decoded `operands`
- *                          array.
- *                          Must be equal to the value of `instruction.operand_count_visible`.
- * @param   buffer          A pointer to the output buffer.
- * @param   length          The length of the output buffer (in bytes).
- * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
- *                          to print relative addresses.
- * @param   token           Receives a pointer to the first token in the output buffer.
  * @param   user_data       A pointer to user-defined data which can be used in custom formatter
  *                          callbacks.
  *
  * @return  A zyan status code.
  */
-ZYDIS_EXPORT ZyanStatus ZydisFormatterTokenizeInstructionEx(const ZydisFormatter* formatter,
+ZYDIS_EXPORT ZyanStatus ZydisFormatterTokenizeInstruction(const ZydisFormatter* formatter,
     const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operands,
     ZyanU8 operand_count, void* buffer, ZyanUSize length, ZyanU64 runtime_address,
     ZydisFormatterTokenConst** token, void* user_data);

--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -1117,36 +1117,14 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterTokenizeInstruction(const ZydisFormatter* 
  * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
  *                          to print relative addresses.
  * @param   token           Receives a pointer to the first token in the output buffer.
- *
- * @return  A zyan status code.
- *
- * Use `ZydisFormatterTokenizeInstruction` or `ZydisFormatterTokenizeInstructionEx` to tokenize a
- * complete instruction.
- */
-ZYDIS_EXPORT ZyanStatus ZydisFormatterTokenizeOperand(const ZydisFormatter* formatter,
-    const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operand,
-    void* buffer, ZyanUSize length, ZyanU64 runtime_address, ZydisFormatterTokenConst** token);
-
-/**
- * Tokenizes the given operand and writes it into the output buffer.
- *
- * @param   formatter       A pointer to the `ZydisFormatter` instance.
- * @param   instruction     A pointer to the `ZydisDecodedInstruction` struct.
- * @param   operand         A pointer to the `ZydisDecodedOperand` struct of the operand to format.
- * @param   buffer          A pointer to the output buffer.
- * @param   length          The length of the output buffer (in bytes).
- * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
- *                          to print relative addresses.
- * @param   token           Receives a pointer to the first token in the output buffer.
  * @param   user_data       A pointer to user-defined data which can be used in custom formatter
  *                          callbacks.
  *
  * @return  A zyan status code.
  *
- * Use `ZydisFormatterTokenizeInstruction` or `ZydisFormatterTokenizeInstructionEx` to tokenize a
- * complete instruction.
+ * Use `ZydisFormatterTokenizeInstruction` to tokenize a complete instruction.
  */
-ZYDIS_EXPORT ZyanStatus ZydisFormatterTokenizeOperandEx(const ZydisFormatter* formatter,
+ZYDIS_EXPORT ZyanStatus ZydisFormatterTokenizeOperand(const ZydisFormatter* formatter,
     const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operand,
     void* buffer, ZyanUSize length, ZyanU64 runtime_address, ZydisFormatterTokenConst** token,
     void* user_data);

--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -1046,32 +1046,12 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterSetHook(ZydisFormatter* formatter,
  * @param   length          The length of the output buffer (in characters).
  * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
  *                          to print relative addresses.
- *
- * @return  A zyan status code.
- */
-ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatInstruction(const ZydisFormatter* formatter,
-    const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operands,
-    ZyanU8 operand_count, char* buffer, ZyanUSize length, ZyanU64 runtime_address);
-
-/**
- * Formats the given instruction and writes it into the output buffer.
- *
- * @param   formatter       A pointer to the `ZydisFormatter` instance.
- * @param   instruction     A pointer to the `ZydisDecodedInstruction` struct.
- * @param   operands        A pointer to the decoded operands array.
- * @param   operand_count   The number of operands to format and read from the decoded `operands`
- *                          array.
- *                          Must be equal to the value of `instruction.operand_count_visible`.
- * @param   buffer          A pointer to the output buffer.
- * @param   length          The length of the output buffer (in characters).
- * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
- *                          to print relative addresses.
  * @param   user_data       A pointer to user-defined data which can be used in custom formatter
  *                          callbacks.
  *
  * @return  A zyan status code.
  */
-ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatInstructionEx(const ZydisFormatter* formatter,
+ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatInstruction(const ZydisFormatter* formatter,
     const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operands,
     ZyanU8 operand_count, char* buffer, ZyanUSize length, ZyanU64 runtime_address,
     void* user_data);

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -485,14 +485,6 @@ ZyanStatus ZydisFormatterFormatInstruction(const ZydisFormatter* formatter,
 
 ZyanStatus ZydisFormatterFormatOperand(const ZydisFormatter* formatter,
     const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operand,
-    char* buffer, ZyanUSize length, ZyanU64 runtime_address)
-{
-    return ZydisFormatterFormatOperandEx(formatter, instruction, operand, buffer, length,
-        runtime_address, ZYAN_NULL);
-}
-
-ZyanStatus ZydisFormatterFormatOperandEx(const ZydisFormatter* formatter,
-    const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operand,
     char* buffer, ZyanUSize length, ZyanU64 runtime_address, void* user_data)
 {
     if (!formatter || !instruction || !operand || !buffer || (length == 0))

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -543,15 +543,6 @@ ZyanStatus ZydisFormatterFormatOperand(const ZydisFormatter* formatter,
 ZyanStatus ZydisFormatterTokenizeInstruction(const ZydisFormatter* formatter,
     const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operands,
     ZyanU8 operand_count, void* buffer, ZyanUSize length, ZyanU64 runtime_address,
-    ZydisFormatterTokenConst** token)
-{
-    return ZydisFormatterTokenizeInstructionEx(formatter, instruction, operands, operand_count,
-        buffer, length, runtime_address, token, ZYAN_NULL);
-}
-
-ZyanStatus ZydisFormatterTokenizeInstructionEx(const ZydisFormatter* formatter,
-    const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operands,
-    ZyanU8 operand_count, void* buffer, ZyanUSize length, ZyanU64 runtime_address,
     ZydisFormatterTokenConst** token, void* user_data)
 {
     if (!formatter || !instruction || (operand_count && !operands) ||

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -449,14 +449,6 @@ ZyanStatus ZydisFormatterSetHook(ZydisFormatter* formatter, ZydisFormatterFuncti
 
 ZyanStatus ZydisFormatterFormatInstruction(const ZydisFormatter* formatter,
     const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operands,
-    ZyanU8 operand_count, char* buffer, ZyanUSize length, ZyanU64 runtime_address)
-{
-     return ZydisFormatterFormatInstructionEx(formatter, instruction, operands, operand_count,
-         buffer, length, runtime_address, ZYAN_NULL);
-}
-
-ZyanStatus ZydisFormatterFormatInstructionEx(const ZydisFormatter* formatter,
-    const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operands,
     ZyanU8 operand_count, char* buffer, ZyanUSize length, ZyanU64 runtime_address, void* user_data)
 {
     if (!formatter || !instruction || (operand_count && !operands) ||

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -589,14 +589,6 @@ ZyanStatus ZydisFormatterTokenizeInstruction(const ZydisFormatter* formatter,
 
 ZyanStatus ZydisFormatterTokenizeOperand(const ZydisFormatter* formatter,
     const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operand,
-    void* buffer, ZyanUSize length, ZyanU64 runtime_address, ZydisFormatterTokenConst** token)
-{
-    return ZydisFormatterTokenizeOperandEx(formatter, instruction, operand, buffer, length,
-        runtime_address, token, ZYAN_NULL);
-}
-
-ZyanStatus ZydisFormatterTokenizeOperandEx(const ZydisFormatter* formatter,
-    const ZydisDecodedInstruction* instruction, const ZydisDecodedOperand* operand,
     void* buffer, ZyanUSize length, ZyanU64 runtime_address, ZydisFormatterTokenConst** token,
     void* user_data)
 {

--- a/tools/ZydisDisasm.c
+++ b/tools/ZydisDisasm.c
@@ -144,7 +144,7 @@ int main(int argc, char** argv)
 
             ZydisFormatterFormatInstruction(&formatter, &instruction, operands, 
                 instruction.operand_count_visible, format_buffer, sizeof(format_buffer),
-                runtime_address);
+                runtime_address, ZYAN_NULL);
             ZYAN_PUTS(format_buffer);
 
             read_offset += instruction.length;

--- a/tools/ZydisFuzzDecoder.c
+++ b/tools/ZydisFuzzDecoder.c
@@ -134,7 +134,7 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void* stream_ctx)
     // Allow the control block to artificially restrict the buffer size.
     ZyanUSize output_len = ZYAN_MIN(sizeof(format_buffer), control_block.formatter_max_len);
     ZydisFormatterFormatInstruction(&formatter, &instruction, operands,
-        instruction.operand_count_visible, format_buffer, output_len, control_block.u64);
+        instruction.operand_count_visible, format_buffer, output_len, control_block.u64, NULL);
 
     // Fuzz tokenizer.
     const ZydisFormatterToken* token;

--- a/tools/ZydisFuzzDecoder.c
+++ b/tools/ZydisFuzzDecoder.c
@@ -168,7 +168,7 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void* stream_ctx)
 
         // Fuzz single operand tokenization.
         ZydisFormatterTokenizeOperand(&formatter, &instruction, op, format_buffer, output_len,
-            control_block.u64, &token);
+            control_block.u64, &token, NULL);
 
         // Address translation helper.
         ZyanU64 abs_addr;

--- a/tools/ZydisFuzzDecoder.c
+++ b/tools/ZydisFuzzDecoder.c
@@ -163,7 +163,7 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void* stream_ctx)
         const ZydisDecodedOperand* op = &operands[op_idx];
 
         ZydisFormatterFormatOperand(&formatter, &instruction, op, format_buffer, output_len,
-            control_block.u64);
+            control_block.u64, NULL);
 
         // Fuzz single operand tokenization.
         ZydisFormatterTokenizeOperand(&formatter, &instruction, op, format_buffer, output_len,

--- a/tools/ZydisFuzzDecoder.c
+++ b/tools/ZydisFuzzDecoder.c
@@ -139,7 +139,8 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void* stream_ctx)
     // Fuzz tokenizer.
     const ZydisFormatterToken* token;
     status = ZydisFormatterTokenizeInstruction(&formatter, &instruction, operands,
-        instruction.operand_count_visible, format_buffer, output_len, control_block.u64, &token);
+        instruction.operand_count_visible, format_buffer, output_len, control_block.u64, &token,
+        NULL);
 
     // Walk tokens.
     while (ZYAN_SUCCESS(status))

--- a/tools/ZydisFuzzShared.c
+++ b/tools/ZydisFuzzShared.c
@@ -119,7 +119,7 @@ void ZydisPrintInstruction(const ZydisDecodedInstruction* instruction,
 
     char buffer[256];
     ZydisFormatterFormatInstruction(&formatter, instruction, operands, operand_count, buffer,
-        sizeof(buffer), 0);
+        sizeof(buffer), 0, NULL);
     printf(" %s\n", buffer);
 }
 

--- a/tools/ZydisInfo.c
+++ b/tools/ZydisInfo.c
@@ -1001,7 +1001,7 @@ static void PrintDisassembly(const ZydisDecodedInstruction* instruction,
 
     PrintValueLabel("ABSOLUTE");
     if (!ZYAN_SUCCESS(status = ZydisFormatterTokenizeInstruction(&formatter, instruction, operands,
-        instruction->operand_count_visible, buffer, sizeof(buffer), 0, &token)))
+        instruction->operand_count_visible, buffer, sizeof(buffer), 0, &token, NULL)))
     {
         PrintStatusError(status, "Failed to tokenize instruction");
         exit(status);
@@ -1010,7 +1010,7 @@ static void PrintDisassembly(const ZydisDecodedInstruction* instruction,
     PrintValueLabel("RELATIVE");
     if (!ZYAN_SUCCESS(status = ZydisFormatterTokenizeInstruction(&formatter, instruction, operands,
         instruction->operand_count_visible, buffer, sizeof(buffer), ZYDIS_RUNTIME_ADDRESS_NONE,
-        &token)))
+        &token, NULL)))
     {
         PrintStatusError(status, "Failed to tokenize instruction");
         exit(status);


### PR DESCRIPTION
This PR removes the `Ex` variants of various formatter functions. Their functionality is instead integrated into the non-`Ex` variant. Having the `Ex` variants effectively doubled the complexity of our public formatter interface and each only had a single additional argument. This additional argument can trivially be passed with as `NULL`, which I believe should be intuitive to most seasoned C programmers.

When porting the various examples I varied between using `NULL` and `ZYAN_NULL`. I chose one or the other depending on whether the example otherwise prefers Zycore or standard C constructs. We should probably normalize that across all examples at some point.