### PR TITLE
Formatter: make `operand_count` check less strict

### DIFF
--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -1039,9 +1039,8 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterSetHook(ZydisFormatter* formatter,
  * @param   formatter       A pointer to the `ZydisFormatter` instance.
  * @param   instruction     A pointer to the `ZydisDecodedInstruction` struct.
  * @param   operands        A pointer to the decoded operands array.
- * @param   operand_count   The number of operands to format and read from the decoded `operands`
- *                          array.
- *                          Must be equal to the value of `instruction.operand_count_visible`.
+ * @param   operand_count   The length of the `operands` array. Must be equal to or greater than
+ *                          the value of `instruction->operand_count_visible`.
  * @param   buffer          A pointer to the output buffer.
  * @param   length          The length of the output buffer (in characters).
  * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`
@@ -1088,9 +1087,8 @@ ZYDIS_EXPORT ZyanStatus ZydisFormatterFormatOperand(const ZydisFormatter* format
  * @param   formatter       A pointer to the `ZydisFormatter` instance.
  * @param   instruction     A pointer to the `ZydisDecodedInstruction` struct.
  * @param   operands        A pointer to the decoded operands array.
- * @param   operand_count   The number of operands to format and read from the decoded `operands`
- *                          array.
- *                          Must be equal to the value of `instruction.operand_count_visible`.
+ * @param   operand_count   The length of the `operands` array. Must be equal to or greater than
+ *                          the value of `instruction->operand_count_visible`.
  * @param   buffer          A pointer to the output buffer.
  * @param   length          The length of the output buffer (in bytes).
  * @param   runtime_address The runtime address of the instruction or `ZYDIS_RUNTIME_ADDRESS_NONE`

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -453,7 +453,7 @@ ZyanStatus ZydisFormatterFormatInstruction(const ZydisFormatter* formatter,
 {
     if (!formatter || !instruction || (operand_count && !operands) ||
         (operand_count > ZYDIS_MAX_OPERAND_COUNT) ||
-        (operand_count != instruction->operand_count_visible) || !buffer || (length == 0))
+        (operand_count < instruction->operand_count_visible) || !buffer || (length == 0))
     {
         return ZYAN_STATUS_INVALID_ARGUMENT;
     }
@@ -547,7 +547,7 @@ ZyanStatus ZydisFormatterTokenizeInstruction(const ZydisFormatter* formatter,
 {
     if (!formatter || !instruction || (operand_count && !operands) ||
         (operand_count > ZYDIS_MAX_OPERAND_COUNT) || 
-        (operand_count != instruction->operand_count_visible) || !buffer ||
+        (operand_count < instruction->operand_count_visible) || !buffer ||
         (length <= sizeof(ZydisFormatterToken)) || !token)
     {
         return ZYAN_STATUS_INVALID_ARGUMENT;


### PR DESCRIPTION
This PR changes the `operand_count` check to be less strict, allowing the user to simply pass `sizeof(operand_array)` as the operand count. The count is passed exclusively as an additional sanity check for the user and I find the new behavior much more intuitive. If I see a size argument following a pointer argument, I automatically assume it to receive the array length.