### PR TITLE
Doc: switch Doxygen theme

### DIFF
--- a/Doxyfile-mcss
+++ b/Doxyfile-mcss
@@ -1,7 +1,0 @@
-@INCLUDE                = Doxyfile
-GENERATE_HTML           = NO
-GENERATE_XML            = YES
-XML_PROGRAMLISTING      = NO
-##!M_LINKS_NAVBAR1      = modules files
-##!M_LINKS_NAVBAR2      =
-##!M_FILE_TREE_EXPAND_LEVELS = 2

--- a/Doxyfile-themed
+++ b/Doxyfile-themed
@@ -1,0 +1,4 @@
+@INCLUDE               = Doxyfile
+GENERATE_TREEVIEW      = YES
+HTML_EXTRA_STYLESHEET  = ../doxygen-awesome-css/doxygen-awesome.css \
+                         ../doxygen-awesome-css/doxygen-awesome-sidebar-only.css

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build install amalgamate clean test doc-plain doc-mcss
 
 BUILD_DIR ?= build
-MCSS_DIR  ?=../m.css
+CSS_DIR   ?= ../doxygen-awesome-css
 
 build: dependencies/zycore/CMakeLists.txt
 	@if ! command -v cmake &> /dev/null; then \
@@ -28,12 +28,12 @@ test: build
 doc-plain:
 	doxygen
 
-doc-mcss:
-	@if [ ! -d "../m.css" ]; then \
-		git clone https://github.com/mosra/m.css.git $(MCSS_DIR); \
+doc-themed:
+	@if [ ! -d "$(CSS_DIR)" ]; then \
+		git clone https://github.com/jothepro/doxygen-awesome-css.git $(CSS_DIR); \
 	fi
 
-	$(MCSS_DIR)/documentation/doxygen.py Doxyfile-mcss
+	doxygen Doxyfile-themed
 
 dependencies/zycore/CMakeLists.txt:
 	@if ! command -v git &> /dev/null; then \


### PR DESCRIPTION
This PR replaces the previous m.css theme with [doxygen-awesome-css](https://github.com/jothepro/doxygen-awesome-css). 

While m.css looks great, it has a bunch of problems when used with C. Namely, it generates all symbols and function names in C++ style and doesn't support nested structures well at all. It also had a tendency of somehow omitting documentation for some types. A lot of these issues are down to m.css having a custom HTML generator and thus having to explicitly support each of these features.

The theme that this PR switches to, doxygen-awesome-css, takes the much simpler route of re-styling the existing HTML with CSS and should thus be a lot less prone to errors.

