### PR TITLE
CI: add automated documentation builds

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,49 @@
+name: Doc
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish-doc:
+    name: Build and publish documentation
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0  # push all branches and tags
+      - name: Install doxygen
+        run: |
+          sudo apt-get install -y doxygen
+      - name: Download & install zydoc
+        run: |
+          wget -O zydoc.tar.gz https://github.com/zyantific/zydoc/releases/download/v0.3.0/zydoc_v0.3.0_x86_64-unknown-linux-musl.tar.gz
+          tar xfv zydoc.tar.gz
+          mv zydoc /usr/local/bin
+      - name: Generate documentation
+        run: >-
+          zydoc
+          --repo .
+          --output-dir doc.zydis.re
+          --config-ref master
+          --doxyfile ./Doxyfile-themed
+          --refs 'refs/heads/master'
+          --refs 'refs/tags/.*'
+          --exclude-refs 'refs/tags/v1.*'
+      - name: Publish documentation
+        uses: cpina/github-action-push-to-another-repository@v1.5
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.DOCS_ZYDIS_RE_SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'doc.zydis.re'
+          destination-github-username: 'zyantific'
+          destination-repository-name: 'doc.zydis.re'
+          user-name: zydis-doc-bot
+          user-email: doc-bot@zydis.re
+          target-branch: main

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - No dynamic memory allocation ("malloc")
 - Thread-safe by design
 - Very small file-size overhead compared to other common disassembler libraries
-- [Complete doxygen documentation](https://zydis.re/doc/3/)
+- [Complete doxygen documentation](https://doc.zydis.re/)
 - Absolutely no third party dependencies — not even libc
   - Should compile on any platform with a working C11 compiler
   - Tested on Windows, macOS, FreeBSD, Linux and UEFI, both user and kernel mode


### PR DESCRIPTION
I finally took the time to implement automated documentation builds. The actual generator lives in [a separate repository](https://github.com/zyantific/zydoc) and is downloaded here via a fully statically linked executable. 

Documentation is currently built for all tags and the master branch. The build always uses the Doxyfile from master to ensure consistent documentation appearance. zydoc then generates an `index.html` containing links to all built documentation versions.

The zydoc output is then pushed into the (private) [doc.zydis.re](https://github.com/zyantific/doc.zydis.re) repository which is automatically deployed to https://doc.zydis.re via [Cloudflare Pages](https://pages.cloudflare.com/).

~The index file is currently very plain, but @ChristianK43 has already agreed to build us a fancier one in the future~ (**update**: implemented!). ~I also intend to extend zydoc to inject a version selector displayed in the bottom right into each HTML file generated by Doxygen in order to simplify navigation between versions at a later point (e.g. see https://docs.djangoproject.com/en/4.0/ for a website with a similar approach).~ (**update 2:** also implemented!)

Once this PR is approved and merged, I'll additionally set up redirects for the old documentation paths on `https://zydis.re/doc/`.