### PR TITLE
Doc: group important macros and refer to them

### DIFF
--- a/include/Zydis/DecoderTypes.h
+++ b/include/Zydis/DecoderTypes.h
@@ -268,6 +268,15 @@ typedef struct ZydisDecodedOperand_
 typedef ZyanU32 ZydisAccessedFlagsMask;
 
 /**
+ * @defgroup decoder_cpu_flags CPU flags
+ * @ingroup decoder
+ *
+ * Constants used for testing CPU flags accessed by an instruction.
+ *
+ * @{
+ */
+
+/**
  * Carry flag.
  */
 #define ZYDIS_CPUFLAG_CF    (1ul <<  0)
@@ -337,6 +346,19 @@ typedef ZyanU32 ZydisAccessedFlagsMask;
 #define ZYDIS_CPUFLAG_ID    (1ul << 21)
 
 /**
+ * @}
+ */
+
+/**
+ * @defgroup decoder_fpu_flags FPU flags
+ * @ingroup decoder
+ *
+ * Constants used for testing FPU flags accessed by an instruction.
+ *
+ * @{
+ */
+
+/**
  * FPU condition-code flag 0.
  */
 #define ZYDIS_FPUFLAG_C0    (1ul <<  0)
@@ -352,6 +374,10 @@ typedef ZyanU32 ZydisAccessedFlagsMask;
  * FPU condition-code flag 3.
  */
 #define ZYDIS_FPUFLAG_C3    (1ul <<  3)
+
+/**
+ * @}
+ */
 
 /*
  * Information about CPU/FPU flags accessed by the instruction.
@@ -1009,18 +1035,20 @@ typedef struct ZydisDecodedInstruction_
      */
     ZyanU8 operand_count_visible;
     /**
-     * Instruction attributes.
+     * See @ref InstructionAttributeMacros.
      */
     ZydisInstructionAttributes attributes;
     /**
      * Information about CPU flags accessed by the instruction.
      *
      * The bits in the masks correspond to the actual bits in the `FLAGS/EFLAGS/RFLAGS`
-     * register.
+     * register. See @ref CPUFlagMacros.
      */
     const ZydisAccessedFlags* cpu_flags;
     /**
      * Information about FPU flags accessed by the instruction.
+     * 
+     * See @ref FPUFlagMacros.
      */
     const ZydisAccessedFlags* fpu_flags;
     /**

--- a/include/Zydis/SharedTypes.h
+++ b/include/Zydis/SharedTypes.h
@@ -483,6 +483,15 @@ typedef enum ZydisOpcodeMap_
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
+ * @defgroup instruction_attributes Instruction attributes
+ *
+ * Constants describing various properties of an instruction. Used in the 
+ * @ref ZydisDecodedInstruction.attributes and @ref ZydisEncoderRequest.prefixes fields.
+ *
+ * @{
+ */
+
+/**
  * Defines the `ZydisInstructionAttributes` data-type.
  */
 typedef ZyanU64 ZydisInstructionAttributes;
@@ -702,6 +711,10 @@ typedef ZyanU64 ZydisInstructionAttributes;
  * This attribute is mainly used by the encoder.
  */
 #define ZYDIS_ATTRIB_HAS_EVEX_B                 (1ULL << 45) // TODO: rename
+
+/**
+ * @}
+ */
 
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/include/Zydis/Zydis.h
+++ b/include/Zydis/Zydis.h
@@ -63,6 +63,14 @@
 extern "C" {
 #endif
 
+/**
+ * @addtogroup version Version
+ *
+ * Functions for checking the library version and build options.
+ *
+ * @{
+ */
+
 /* ============================================================================================== */
 /* Macros                                                                                         */
 /* ============================================================================================== */
@@ -141,12 +149,6 @@ typedef enum ZydisFeature_
 /* ============================================================================================== */
 
 /**
- * @addtogroup version Version
- * Functions for checking the library version and build options.
- * @{
- */
-
-/**
  * Returns the zydis version.
  *
  * @return  The zydis version.
@@ -166,11 +168,11 @@ ZYDIS_EXPORT ZyanU64 ZydisGetVersion(void);
  */
 ZYDIS_EXPORT ZyanStatus ZydisIsFeatureEnabled(ZydisFeature feature);
 
+/* ============================================================================================== */
+
 /**
  * @}
  */
-
-/* ============================================================================================== */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I noticed that flag fields that use macros to define their values are currently very tough to navigate in our documentation. This PR resolves this by manually grouping them and referring to the respective groups. There's probably more macro groups that could profit from this -- I only covered the most important ones here.