### PR TITLE
Decoder: simplify ZydisDecoderDecodeFull API

### DIFF
--- a/examples/Disassemble.c
+++ b/examples/Disassemble.c
@@ -61,10 +61,9 @@ int main()
     ZyanUSize offset = 0;
     const ZyanUSize length = sizeof(data);
     ZydisDecodedInstruction instruction;
-    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
+    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
     while (ZYAN_SUCCESS(ZydisDecoderDecodeFull(&decoder, data + offset, length - offset,
-        &instruction, operands, ZYDIS_MAX_OPERAND_COUNT_VISIBLE,
-        ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY)))
+        &instruction, operands)))
     {
         // Print current instruction pointer.
         printf("%016" PRIX64 "  ", runtime_address);

--- a/examples/Formatter01.c
+++ b/examples/Formatter01.c
@@ -115,11 +115,10 @@ static void DisassembleBuffer(ZydisDecoder* decoder, ZyanU8* data, ZyanUSize len
     ZyanU64 runtime_address = 0x007FFFFFFF400000;
 
     ZydisDecodedInstruction instruction;
-    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
+    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
     char buffer[256];
 
-    while (ZYAN_SUCCESS(ZydisDecoderDecodeFull(decoder, data, length, &instruction, operands,
-        ZYDIS_MAX_OPERAND_COUNT_VISIBLE, ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY)))
+    while (ZYAN_SUCCESS(ZydisDecoderDecodeFull(decoder, data, length, &instruction, operands)))
     {
         ZYAN_PRINTF("%016" PRIX64 "  ", runtime_address);
 

--- a/examples/Formatter02.c
+++ b/examples/Formatter02.c
@@ -211,12 +211,11 @@ static void DisassembleBuffer(ZydisDecoder* decoder, ZyanU8* data, ZyanUSize len
     ZyanU64 runtime_address = 0x007FFFFFFF400000;
 
     ZydisDecodedInstruction instruction;
-    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
+    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
     ZydisCustomUserData user_data;
     char buffer[256];
 
-    while (ZYAN_SUCCESS(ZydisDecoderDecodeFull(decoder, data, length, &instruction, operands,
-        ZYDIS_MAX_OPERAND_COUNT_VISIBLE, ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY)))
+    while (ZYAN_SUCCESS(ZydisDecoderDecodeFull(decoder, data, length, &instruction, operands)))
     {
         ZYAN_PRINTF("%016" PRIX64 "  ", runtime_address);
 

--- a/examples/Formatter03.c
+++ b/examples/Formatter03.c
@@ -71,11 +71,10 @@ static void DisassembleBuffer(ZydisDecoder* decoder, ZyanU8* data, ZyanUSize len
     ZyanU64 runtime_address = 0x007FFFFFFF400000;
 
     ZydisDecodedInstruction instruction;
-    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
+    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
     char buffer[256];
 
-    while (ZYAN_SUCCESS(ZydisDecoderDecodeFull(decoder, data, length, &instruction, operands,
-        ZYDIS_MAX_OPERAND_COUNT_VISIBLE, ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY)))
+    while (ZYAN_SUCCESS(ZydisDecoderDecodeFull(decoder, data, length, &instruction, operands)))
     {
         const ZydisFormatterToken* token;
         if (ZYAN_SUCCESS(ZydisFormatterTokenizeInstruction(&formatter, &instruction, operands,

--- a/examples/RewriteCode.c
+++ b/examples/RewriteCode.c
@@ -89,9 +89,8 @@ int main(int argc, char** argv)
 
     // Attempt to decode the given bytes as an X86-64 instruction.
     ZydisDecodedInstruction instr;
-    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
-    ZyanStatus status = ZydisDecoderDecodeFull(&decoder, bytes, num_bytes, &instr, operands,
-        ZYDIS_MAX_OPERAND_COUNT_VISIBLE, ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY);
+    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
+    ZyanStatus status = ZydisDecoderDecodeFull(&decoder, bytes, num_bytes, &instr, operands);
     if (ZYAN_FAILED(status))
     {
         fprintf(stderr, "Failed to decode instruction: %02" PRIx32, status);
@@ -157,7 +156,7 @@ int main(int argc, char** argv)
 
     // Decode and print the new instruction. We re-use the old buffers.
     ExpectSuccess(ZydisDecoderDecodeFull(&decoder, new_bytes, new_instr_length, &instr,
-        operands, ZYDIS_MAX_OPERAND_COUNT_VISIBLE, ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY));
+        operands));
     ExpectSuccess(ZydisFormatterFormatInstruction(&fmt, &instr, operands,
         instr.operand_count_visible, fmt_buf, sizeof(fmt_buf), 0, NULL));
     printf("New instruction:      %s\n", fmt_buf);

--- a/examples/ZydisWinKernel.c
+++ b/examples/ZydisWinKernel.c
@@ -159,15 +159,14 @@ DriverEntry(
 
     SIZE_T readOffset = 0;
     ZydisDecodedInstruction instruction;
-    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
+    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
     ZyanStatus status;
     CHAR printBuffer[128];
 
     // Start the decode loop
     while ((status = ZydisDecoderDecodeFull(&decoder, 
         (PVOID)(imageBase + entryPointRva + readOffset), length - readOffset, &instruction,
-        operands, ZYDIS_MAX_OPERAND_COUNT_VISIBLE, ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY)) != 
-        ZYDIS_STATUS_NO_MORE_DATA)
+        operands)) != ZYDIS_STATUS_NO_MORE_DATA)
     {
         NT_ASSERT(ZYAN_SUCCESS(status));
         if (!ZYAN_SUCCESS(status))

--- a/include/Zydis/Decoder.h
+++ b/include/Zydis/Decoder.h
@@ -148,20 +148,6 @@ typedef enum ZydisDecoderMode_
 } ZydisDecoderMode;
 
 /* ---------------------------------------------------------------------------------------------- */
-/* Decoder flags                                                                                  */
-/* ---------------------------------------------------------------------------------------------- */
-
-/**
- * Defines the `ZydisDecodingFlags` data-type.
- */
-typedef ZyanU8 ZydisDecodingFlags;
-
-/**
- * Only decode visible operands.
- */
-#define ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY   (1 << 0)
-
-/* ---------------------------------------------------------------------------------------------- */
 /* Decoder struct                                                                                 */
 /* ---------------------------------------------------------------------------------------------- */
 
@@ -232,30 +218,20 @@ ZYDIS_EXPORT ZyanStatus ZydisDecoderEnableMode(ZydisDecoder* decoder, ZydisDecod
  *                          actual size of the instruction -- you don't have to know the size up
  *                          front. This length is merely used to prevent Zydis from doing
  *                          out-of-bounds reads on your buffer.
- * @param   instruction     A pointer to the `ZydisDecodedInstruction` struct, that receives the
- *                          details about the decoded instruction.
- * @param   operands        The array that receives the decoded operands.
- *                          Refer to `ZYDIS_MAX_OPERAND_COUNT` or `ZYDIS_MAX_OPERAND_COUNT_VISIBLE`
- *                          when allocating space for the array to ensure that the buffer size is
- *                          sufficient to always fit all instruction operands.
- * @param   operand_count   The length of the `operands` array.
- *                          This argument as well limits the maximum amount of operands to decode.
- *                          If this value is `0`, no operands will be decoded and `ZYAN_NULL` will
- *                          be accepted for the `operands` argument.
- * @param   flags           Additional decoding flags.
+ * @param   instruction     A pointer to the `ZydisDecodedInstruction` struct receiving the details
+ *                          about the decoded instruction.
+ * @param   operands        A pointer to an array with `ZYDIS_MAX_OPERAND_COUNT` entries that
+ *                          receives the decoded operands. The number of operands decoded is
+ *                          determined by the `instruction.operand_count` field. Excess entries are
+ *                          zeroed.
  *
- * This function decodes `MIN(operand_count, instruction.operand_count)` operands. The excess
- * items in the `operands` array are not zeroed. The `instruction.operand_count` field must be
- * checked in addition to the passed `operand_count`, to determine the actual amount of decoded
- * operands.
- *
- * The `ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY` can be passed to only decode visible operands. In this
- * case `MIN(operand_count, instruction.operand_count_visible)` operands are decoded by this
- * function and the `instruction.operand_count_visible` field must be checked in addition to the
- * passed `operand_count`, to determine the actual amount of decoded operands.
- *
- * Please refer to `ZydisDecoderDecodeInstruction` and `ZydisDecoderDecodeOperands`, if operand
- * decoding is not required or should be done separately.
+ * This is a convenience function that combines the following functions into one call:
+ * 
+ *   - `ZydisDecoderDecodeInstruction`
+ *   - `ZydisDecoderDecodeOperands`
+ * 
+ * Please refer to `ZydisDecoderDecodeInstruction` if operand decoding is not required or should
+ * be done separately (`ZydisDecoderDecodeOperands`).
  *
  * This function is not available in MINIMAL_MODE.
  *
@@ -263,7 +239,7 @@ ZYDIS_EXPORT ZyanStatus ZydisDecoderEnableMode(ZydisDecoder* decoder, ZydisDecod
  */
 ZYDIS_EXPORT ZyanStatus ZydisDecoderDecodeFull(const ZydisDecoder* decoder,
     const void* buffer, ZyanUSize length, ZydisDecodedInstruction* instruction,
-    ZydisDecodedOperand* operands, ZyanU8 operand_count, ZydisDecodingFlags flags);
+    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT]);
 
 /**
  * Decodes the instruction in the given input `buffer`.

--- a/tools/ZydisDisasm.c
+++ b/tools/ZydisDisasm.c
@@ -125,14 +125,13 @@ int main(int argc, char** argv)
         buffer_size += buffer_remaining;
 
         ZydisDecodedInstruction instruction;
-        ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
+        ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
         ZyanStatus status;
         ZyanUSize read_offset = 0;
         char format_buffer[256];
 
         while ((status = ZydisDecoderDecodeFull(&decoder, buffer + read_offset,
-            buffer_size - read_offset, &instruction, operands, ZYDIS_MAX_OPERAND_COUNT_VISIBLE,
-            ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY)) != ZYDIS_STATUS_NO_MORE_DATA)
+            buffer_size - read_offset, &instruction, operands)) != ZYDIS_STATUS_NO_MORE_DATA)
         {
             const ZyanU64 runtime_address = read_offset_base + read_offset;
 

--- a/tools/ZydisFuzzDecoder.c
+++ b/tools/ZydisFuzzDecoder.c
@@ -120,8 +120,7 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void* stream_ctx)
     ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
 
     // Fuzz decoder.
-    ZyanStatus status = ZydisDecoderDecodeFull(&decoder, buffer, input_len, &instruction, 
-        operands, ZYDIS_MAX_OPERAND_COUNT, 0);
+    ZyanStatus status = ZydisDecoderDecodeFull(&decoder, buffer, input_len, &instruction, operands);
     if (!ZYAN_SUCCESS(status))
     {
         return EXIT_FAILURE;

--- a/tools/ZydisFuzzEncoder.c
+++ b/tools/ZydisFuzzEncoder.c
@@ -61,7 +61,7 @@ void ZydisCompareRequestToInstruction(const ZydisEncoderRequest *request,
 
     // Handle possible KNC overlap
     ZydisDecodedInstruction knc_insn;
-    ZydisDecodedOperand knc_operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
+    ZydisDecodedOperand knc_operands[ZYDIS_MAX_OPERAND_COUNT];
     if (request->mnemonic != insn->mnemonic)
     {
         ZydisDecoder decoder;
@@ -77,7 +77,7 @@ void ZydisCompareRequestToInstruction(const ZydisEncoderRequest *request,
             abort();
         }
         if (!ZYAN_SUCCESS(ZydisDecoderDecodeFull(&decoder, insn_bytes, insn->length, &knc_insn,
-            knc_operands, ZYDIS_MAX_OPERAND_COUNT_VISIBLE, ZYDIS_DFLAG_VISIBLE_OPERANDS_ONLY)))
+            knc_operands)))
         {
             fputs("Failed to decode instruction\n", ZYAN_STDERR);
             abort();
@@ -289,8 +289,8 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void *stream_ctx)
 
     ZydisDecodedInstruction insn1;
     ZydisDecodedOperand operands1[ZYDIS_MAX_OPERAND_COUNT];
-    status = ZydisDecoderDecodeFull(&decoder, encoded_instruction, encoded_length, &insn1, 
-        operands1, ZYDIS_MAX_OPERAND_COUNT, 0);
+    status = ZydisDecoderDecodeFull(&decoder, encoded_instruction, encoded_length, &insn1,
+        operands1);
     if (!ZYAN_SUCCESS(status))
     {
         fputs("Failed to decode instruction\n", ZYAN_STDERR);

--- a/tools/ZydisFuzzReEncoding.c
+++ b/tools/ZydisFuzzReEncoding.c
@@ -75,8 +75,7 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void *stream_ctx)
 
     ZydisDecodedInstruction insn1;
     ZydisDecodedOperand operands1[ZYDIS_MAX_OPERAND_COUNT];
-    ZyanStatus status = ZydisDecoderDecodeFull(&decoder, buffer, input_len, &insn1, operands1, 
-        ZYDIS_MAX_OPERAND_COUNT, 0);
+    ZyanStatus status = ZydisDecoderDecodeFull(&decoder, buffer, input_len, &insn1, operands1);
     if (!ZYAN_SUCCESS(status))
     {
         return EXIT_FAILURE;

--- a/tools/ZydisFuzzShared.c
+++ b/tools/ZydisFuzzShared.c
@@ -387,8 +387,8 @@ void ZydisReEncodeInstruction(const ZydisDecoder *decoder, const ZydisDecodedIns
 
     ZydisDecodedInstruction insn2;
     ZydisDecodedOperand operands2[ZYDIS_MAX_OPERAND_COUNT];
-    status = ZydisDecoderDecodeFull(decoder, encoded_instruction, encoded_length, &insn2, 
-        operands2, ZYDIS_MAX_OPERAND_COUNT, 0);
+    status = ZydisDecoderDecodeFull(decoder, encoded_instruction, encoded_length, &insn2,
+        operands2);
     if (!ZYAN_SUCCESS(status))
     {
         fputs("Failed to decode re-encoded instruction\n", ZYAN_STDERR);

--- a/tools/ZydisInfo.c
+++ b/tools/ZydisInfo.c
@@ -464,7 +464,7 @@ static void PrintSizeOptimizedForm(const ZydisDecoder* decoder,
     }
 
     ZydisDecodedInstruction new_instruction;
-    status = ZydisDecoderDecodeFull(decoder, &data, len, &new_instruction, ZYAN_NULL, 0, 0);
+    status = ZydisDecoderDecodeInstruction(decoder, ZYAN_NULL, &data, len, &new_instruction);
     if (!ZYAN_SUCCESS(status))
     {
         PrintStatusError(status, "Could not decode instruction");
@@ -1381,8 +1381,7 @@ int main(int argc, char** argv)
     ZydisDecodedInstruction instruction;
     ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
 
-    status = ZydisDecoderDecodeFull(&decoder, &data, byte_length, &instruction, operands,
-        ZYDIS_MAX_OPERAND_COUNT, 0);
+    status = ZydisDecoderDecodeFull(&decoder, &data, byte_length, &instruction, operands);
     if (!ZYAN_SUCCESS(status))
     {
         PrintStatusError(status, "Could not decode instruction");

--- a/tools/ZydisTestEncoderAbsolute.c
+++ b/tools/ZydisTestEncoderAbsolute.c
@@ -119,7 +119,7 @@ static ZyanBool RunTest(ZydisEncoderRequest *req, const char *test_name, ZyanU8 
         return ZYAN_FALSE;
     }
     if (ZYAN_FAILED(ZydisDecoderDecodeFull(&decoder, instruction1, sizeof(instruction1),
-        &dec_instruction, dec_operands, ZYDIS_MAX_OPERAND_COUNT, 0)))
+        &dec_instruction, dec_operands)))
     {
         ZYAN_PRINTF("%s: FAILED TO DECODE INSTRUCTION\n", test_name);
         return ZYAN_FALSE;


### PR DESCRIPTION
As previously discussed in https://github.com/zyantific/zydis/pull/379, this PR simplifies `ZydisDecoderDecodeFull` in order to reduce the overall complexity of our public interface. If people wish to decode less than `ZYDIS_MAX_OPERAND_COUNT` operands, they can simply use the more advanced `ZydisDecoderDecodeInstruction` and `ZydisDecoderDecodeOperands` functions.