### PR TITLE
Makefile: fix `test` recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 
 test: build
 	cd tests && ./regression.py test ../build/ZydisInfo
-	cd tests && ./regression_encoder.py ../build/ZydisFuzz{ReEncoding,Encoder}
+	cd tests && ./regression_encoder.py ../build/Zydis{Fuzz{ReEncoding,Encoder},TestEncoderAbsolute}
 
 doc: configure
 	cmake --build $(BUILD_DIR) --target doc


### PR DESCRIPTION
The recent addition of the new test binary broke the make `test` rule, this PR fixes it again.