### PR TITLE
Remove Doxygen theme from regular builds

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -17,18 +17,21 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          fetch-depth: 0  # push all branches and tags
+          fetch-depth: 0  # fetch all branches and tags
       - name: Install doxygen
         run: |
           sudo apt-get install -y doxygen
-      - name: Clone doxygen theme
-        run: |
-          git clone https://github.com/jothepro/doxygen-awesome-css.git ../doxygen-awesome-css
       - name: Download & install zydoc
         run: |
-          wget -O zydoc.tar.gz https://github.com/zyantific/zydoc/releases/download/v0.3.0/zydoc_v0.3.0_x86_64-unknown-linux-musl.tar.gz
+          wget -O zydoc.tar.gz https://github.com/zyantific/zydoc/releases/download/v0.3.2/zydoc_v0.3.2_x86_64-unknown-linux-musl.tar.gz
           tar xfv zydoc.tar.gz
           mv zydoc /usr/local/bin
+      - name: Clone Doxygen theme
+        run: >-
+          git clone 
+          --depth=1 --branch=v2.1.0 
+          https://github.com/jothepro/doxygen-awesome-css.git 
+          /tmp/doxy-theme
       - name: Generate documentation
         run: >-
           zydoc
@@ -39,6 +42,8 @@ jobs:
           --refs 'refs/heads/master'
           --refs 'refs/tags/.*'
           --exclude-refs 'refs/tags/v1.*'
+          --extra-css /tmp/doxy-theme/doxygen-awesome.css
+          --extra-css /tmp/doxy-theme/doxygen-awesome-sidebar-only.css
       - name: Publish documentation
         uses: cpina/github-action-push-to-another-repository@v1.5
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,21 +405,10 @@ endif ()
 # =============================================================================================== #
 # Doxygen documentation                                                                           #
 # =============================================================================================== #
-if(ZYDIS_BUILD_DOXYGEN)
+
+if (ZYDIS_BUILD_DOXYGEN)
     find_package(Doxygen)
     if (DOXYGEN_FOUND)
-        find_file(DOXYGEN_AWESOME_CSS
-            "doxygen-awesome.css"
-            PATHS "." ".." "/usr/share"
-            PATH_SUFFIXES "doxygen-awesome-css"
-            NO_DEFAULT_PATH
-        )
-        find_file(DOXYGEN_AWESOME_SIDEBAR_ONLY_CSS
-            "doxygen-awesome-sidebar-only.css"
-            PATHS "." ".." "/usr/share"
-            PATH_SUFFIXES "doxygen-awesome-css"
-            NO_DEFAULT_PATH
-        )
         # Read Doxygen options from the Doxyfile and set them as CMake variables
         # to accomodate doxygen_add_docs()
         file(READ "Doxyfile" DOXYFILE)
@@ -457,7 +446,6 @@ if(ZYDIS_BUILD_DOXYGEN)
         set(DOXYGEN_QUIET YES)
         set(DOXYGEN_WARNINGS NO)
         set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)
-        set(DOXYGEN_HTML_EXTRA_STYLESHEET "${DOXYGEN_AWESOME_CSS}" "${DOXYGEN_AWESOME_SIDEBAR_ONLY_CSS}")
 
         doxygen_add_docs(ZydisDoc ${DOC_PATHS} ALL)
 
@@ -466,10 +454,10 @@ if(ZYDIS_BUILD_DOXYGEN)
             DESTINATION "${CMAKE_INSTALL_DOCDIR}/api"
             COMPONENT Documentation
         )
-    else()
+    else ()
         message("Can't generate documentation, Doxygen not found.")
-    endif()
-endif()
+    endif ()
+endif ()
 
 # =============================================================================================== #
 # Manpages                                                                                        #

--- a/Doxyfile-themed
+++ b/Doxyfile-themed
@@ -1,4 +1,0 @@
-@INCLUDE               = Doxyfile
-GENERATE_TREEVIEW      = YES
-HTML_EXTRA_STYLESHEET  = ../doxygen-awesome-css/doxygen-awesome.css \
-                         ../doxygen-awesome-css/doxygen-awesome-sidebar-only.css

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: build
 	cd tests && ./regression_encoder.py ../build/Zydis{Fuzz{ReEncoding,Encoder},TestEncoderAbsolute}
 
 doc: configure
-	cmake --build $(BUILD_DIR) --target doc
+	cmake --build $(BUILD_DIR) --target ZydisDoc
 
 doc-plain:
 	rm -rf "$(CSS_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -30,16 +30,6 @@ test: build
 doc: configure
 	cmake --build $(BUILD_DIR) --target ZydisDoc
 
-doc-plain:
-	rm -rf "$(CSS_DIR)"
-	$(MAKE) doc
-
-doc-themed:
-	@if [ ! -d "$(CSS_DIR)" ]; then \
-		git clone --depth 1 https://github.com/jothepro/doxygen-awesome-css.git $(CSS_DIR); \
-	fi
-	$(MAKE) doc
-
 dependencies/zycore/CMakeLists.txt:
 	@if ! command -v git > /dev/null; then \
 		echo >&2 -n "ERROR: git is not installed. Please either manually place all"; \


### PR DESCRIPTION
The CSS theme caused issues on Windows builds. While I'm sure that we could have fixed them, there was also the question of how the theme should be deployed (submodule, downloaded by CMake, ...). To sidestep these issues entirely, this PR just drops the theme from regular Zydis build scripts entirely, instead injecting it for our CI doc builds via a new switch `--extra-css` that [I added into `v0.3.2` of zydoc](https://github.com/zyantific/zydoc/commit/bf8eb501b7f0ce0c69eebb927656dfbe80deec1a).

I recommend reviewing commit-by-commit.