### PR TITLE
CMake: Enable `CMAKE_MSVC_RUNTIME_LIBRARY` (MSVC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
+    # Enable runtime library selection via CMAKE_MSVC_RUNTIME_LIBRARY
+    cmake_policy(SET CMP0091 NEW)
+endif ()
+
 project(Zydis VERSION 4.0.0.0 LANGUAGES C CXX)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
This PR enables `CMP0091` policy that controls `CMAKE_MSVC_RUNTIME_LIBRARY`. This is a modern way to specify CRT version for MSVC added in CMake 3.15.