### PR TITLE
Disassembler: fix argument type `usize` -> `u64`

### DIFF
--- a/include/Zydis/Disassembler.h
+++ b/include/Zydis/Disassembler.h
@@ -114,7 +114,7 @@ typedef struct ZydisDisassembledInstruction_
  * @return  A zyan status code.
  */
 ZYDIS_EXPORT ZyanStatus ZydisDisassembleIntel(ZydisMachineMode machine_mode,
-    ZyanUSize runtime_address, const void* buffer, ZyanUSize length,
+    ZyanU64 runtime_address, const void* buffer, ZyanUSize length,
     ZydisDisassembledInstruction *instruction);
 
 /**
@@ -123,7 +123,7 @@ ZYDIS_EXPORT ZyanStatus ZydisDisassembleIntel(ZydisMachineMode machine_mode,
  * @copydetails ZydisDisassembleIntel
  */
 ZYDIS_EXPORT ZyanStatus ZydisDisassembleATT(ZydisMachineMode machine_mode,
-    ZyanUSize runtime_address, const void* buffer, ZyanUSize length,
+    ZyanU64 runtime_address, const void* buffer, ZyanUSize length,
     ZydisDisassembledInstruction *instruction);
 
 /* ============================================================================================== */

--- a/src/Disassembler.c
+++ b/src/Disassembler.c
@@ -32,7 +32,7 @@
 /* ============================================================================================== */
 
 static ZyanStatus ZydisDisassemble(ZydisMachineMode machine_mode,
-    ZyanUSize runtime_address, const void* buffer, ZyanUSize length,
+    ZyanU64 runtime_address, const void* buffer, ZyanUSize length,
     ZydisDisassembledInstruction *instruction, ZydisFormatterStyle style)
 {
     if (!buffer || !instruction)
@@ -87,7 +87,7 @@ static ZyanStatus ZydisDisassemble(ZydisMachineMode machine_mode,
 /* ============================================================================================== */
 
 ZyanStatus ZydisDisassembleIntel(ZydisMachineMode machine_mode,
-    ZyanUSize runtime_address, const void* buffer, ZyanUSize length,
+    ZyanU64 runtime_address, const void* buffer, ZyanUSize length,
     ZydisDisassembledInstruction *instruction)
 {
     return ZydisDisassemble(machine_mode, runtime_address, buffer, length, instruction,
@@ -95,7 +95,7 @@ ZyanStatus ZydisDisassembleIntel(ZydisMachineMode machine_mode,
 }
 
 ZyanStatus ZydisDisassembleATT(ZydisMachineMode machine_mode,
-    ZyanUSize runtime_address, const void* buffer, ZyanUSize length,
+    ZyanU64 runtime_address, const void* buffer, ZyanUSize length,
     ZydisDisassembledInstruction *instruction)
 {
     return ZydisDisassemble(machine_mode, runtime_address, buffer, length, instruction,


### PR DESCRIPTION
@Mattiwatti realized that the new disassembler functions have the wrong argument types -- this PR fixes that issue.