### PR TITLE
CMake: remove `CXX` from `project` directive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
     cmake_policy(SET CMP0091 NEW)
 endif ()
 
-project(Zydis VERSION 4.0.0.0 LANGUAGES C CXX)
+project(Zydis VERSION 4.0.0.0 LANGUAGES C)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Zydis currently requests a C++ compiler despite not actually using it. This breaks build on toolchains without a C++ compiler (e.g. musl libc).

@Tachi107 already did the same for zycore a while ago:

https://github.com/zyantific/zycore-c/commit/8f39333a9de5c868063587594f69d2c05de48c38