### PR TITLE
Use ZYAN_DIV64 in ZydisStringAppendDecU64

### DIFF
--- a/src/String.c
+++ b/src/String.c
@@ -122,7 +122,7 @@ ZyanStatus ZydisStringAppendDecU64(ZyanString* string, ZyanU64 value, ZyanU8 pad
     {
         const ZyanU64 value_old = value;
         buffer_write_pointer -= 2;
-        value /= 100;
+        ZYAN_DIV64(value, 100);
         ZYAN_MEMCPY(buffer_write_pointer, &DECIMAL_LOOKUP[(value_old - (value * 100)) * 2], 2);
     }
     buffer_write_pointer -= 2;


### PR DESCRIPTION
Avoid a direct 64bit integer division in ZydisStringAppendDecU64 and use the macro provided by zycore instead, as GCC might generate unwanted calls to arithmetic functions on 32bit platforms.

This is the Zydis counterpart of zyantific/zycore-c#62

Note that this PR needs an update of the dependencies/zycore submodule first.

Thanks.