### PR TITLE
Fix -Wtype-limits warnings by removing redundant assertions

### DIFF
--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -2006,7 +2006,6 @@ static void ZydisSetAttributes(ZydisDecoderState* state, ZydisDecodedInstruction
             /* WRITE     */ ZYDIS_ATTRIB_CPU_STATE_CW,
             /* READWRITE */ ZYDIS_ATTRIB_CPU_STATE_CR | ZYDIS_ATTRIB_CPU_STATE_CW
         };
-        ZYAN_ASSERT(definition->cpu_state < ZYAN_ARRAY_LENGTH(mapping));
         instruction->attributes |= mapping[definition->cpu_state];
     }
 
@@ -2019,7 +2018,6 @@ static void ZydisSetAttributes(ZydisDecoderState* state, ZydisDecodedInstruction
             /* WRITE     */ ZYDIS_ATTRIB_FPU_STATE_CW,
             /* READWRITE */ ZYDIS_ATTRIB_FPU_STATE_CR | ZYDIS_ATTRIB_FPU_STATE_CW
         };
-        ZYAN_ASSERT(definition->fpu_state < ZYAN_ARRAY_LENGTH(mapping));
         instruction->attributes |= mapping[definition->fpu_state];
     }
 
@@ -2032,7 +2030,6 @@ static void ZydisSetAttributes(ZydisDecoderState* state, ZydisDecodedInstruction
             /* WRITE     */ ZYDIS_ATTRIB_XMM_STATE_CW,
             /* READWRITE */ ZYDIS_ATTRIB_XMM_STATE_CR | ZYDIS_ATTRIB_XMM_STATE_CW
         };
-        ZYAN_ASSERT(definition->xmm_state < ZYAN_ARRAY_LENGTH(mapping));
         instruction->attributes |= mapping[definition->xmm_state];
     }
 
@@ -3456,7 +3453,6 @@ static void ZydisSetEffectiveOperandWidth(ZydisDecoderContext* context,
         index += (context->vector_unified.W & 0x01) << 1;
     }
 
-    ZYAN_ASSERT(definition->operand_size_map < ZYAN_ARRAY_LENGTH(operand_size_map));
     ZYAN_ASSERT(index < ZYAN_ARRAY_LENGTH(operand_size_map[definition->operand_size_map]));
 
     instruction->operand_width = operand_size_map[definition->operand_size_map][index];

--- a/src/SharedData.c
+++ b/src/SharedData.c
@@ -115,7 +115,6 @@ const ZydisOperandDefinition* ZydisGetOperandDefinitions(
     {
         return ZYAN_NULL;
     }
-    ZYAN_ASSERT(definition->operand_reference != 0xFFFF);
     return &OPERAND_DEFINITIONS[definition->operand_reference];
 }
 #endif


### PR DESCRIPTION
This was uncovered in the context of WebKit. These assertions are always true as the bitfield variables in question are too small to hold the values that the assertions are comparing against:

- ZydisSetAttributes: The arrays are defined to be larger than the bitfield holding cpu_state, fpu_state, and xmm_state, so the comparison is always true.

- ZydisSetEffectiveOperandWidth: operand_size_map is a 3-bit bitfield, and the arrays have a size 8, thus the comparison is always true.

- ZydisGetOperandDefinitions: operand_reference is a 15-bit bitfield, it can't hold 0xFFFF (which needs 16 bits), so the comparison is always true.

See also https://bugs.webkit.org/show_bug.cgi?id=252309