### PR TITLE
Explicitly zero ZydisDisassemble instruction

### DIFF
--- a/src/Disassembler.c
+++ b/src/Disassembler.c
@@ -40,10 +40,8 @@ static ZyanStatus ZydisDisassemble(ZydisMachineMode machine_mode,
         return ZYAN_STATUS_INVALID_ARGUMENT;
     }
 
-    *instruction = (ZydisDisassembledInstruction)
-    {
-      .runtime_address = runtime_address
-    };
+    ZYAN_MEMSET(instruction, 0, sizeof(*instruction));
+    instruction->runtime_address = runtime_address;
 
     // Derive the stack width from the address width.
     ZydisStackWidth stack_width;


### PR DESCRIPTION
Firstly, thank you for the brilliant library! 

I ran into an issue while compiling the library to webassembly using clang (`-target wasm32-freestanding`).

The `-DZYAN_NO_LIBC` flag works as expected, but I noticed that clang inserts a `memset` call when the `ZydisDisassembledInstruction *instruction` argument of `ZydisDisassemble` is [implicitly zeroed](https://github.com/zyantific/zydis/blob/aeb1b9acf0703fd56dae879c99b05704ea955511/src/Disassembler.c#L43-L46). If I explicitly zero the instruction with `ZYAN_MEMSET` (this PR) then I get the expected result; no `memset` call there, and no libc calls anywhere.

clang doesn't seem to respect the `-ffreestanding` and `-fno-builtins` flags. I'm not sure what flag I need to use (or if one exists) to eliminate the `memset` call. I appreciate that this is probably a clang issue rather than something zydis should concern itself with, but I'll submit this PR either way in case others run into the same issue in future. 