### PR TITLE
Add missing static keywords.

### DIFF
--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -1589,7 +1589,7 @@ static void ZydisDecodeOperandImplicitMemory(const ZydisDecoder* decoder,
 #endif
 
 #ifndef ZYDIS_MINIMAL_MODE
-ZyanStatus ZydisDecodeOperands(const ZydisDecoder* decoder, const ZydisDecoderContext* context,
+static ZyanStatus ZydisDecodeOperands(const ZydisDecoder* decoder, const ZydisDecoderContext* context,
     const ZydisDecodedInstruction* instruction, ZydisDecodedOperand* operands, ZyanU8 operand_count)
 {
     ZYAN_ASSERT(decoder);

--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -3652,7 +3652,7 @@ static ZyanStatus ZydisEmitInstruction(ZydisEncoderInstruction *instruction,
  * @param   def_op      Decoder's operand definition from instruction definition.
  * @param   instruction A pointer to `ZydisEncoderInstruction` struct.
  */
-void ZydisBuildRegisterOperand(const ZydisEncoderOperand *user_op,
+static void ZydisBuildRegisterOperand(const ZydisEncoderOperand *user_op,
     const ZydisOperandDefinition *def_op, ZydisEncoderInstruction *instruction)
 {
     if (def_op->type == ZYDIS_SEMANTIC_OPTYPE_IMPLICIT_REG)

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -55,7 +55,7 @@ static const ZydisFormatter* const FORMATTER_PRESETS[ZYDIS_FORMATTER_STYLE_MAX_V
 /* Helper functions                                                                               */
 /* ---------------------------------------------------------------------------------------------- */
 
-void ZydisFormatterBufferInit(ZydisFormatterBuffer* buffer, char* user_buffer,
+static void ZydisFormatterBufferInit(ZydisFormatterBuffer* buffer, char* user_buffer,
     ZyanUSize length)
 {
     ZYAN_ASSERT(buffer);
@@ -77,7 +77,7 @@ void ZydisFormatterBufferInit(ZydisFormatterBuffer* buffer, char* user_buffer,
     *user_buffer = '\0';
 }
 
-void ZydisFormatterBufferInitTokenized(ZydisFormatterBuffer* buffer,
+static void ZydisFormatterBufferInitTokenized(ZydisFormatterBuffer* buffer,
     ZydisFormatterToken** first_token, void* user_buffer, ZyanUSize length)
 {
     ZYAN_ASSERT(buffer);

--- a/src/String.c
+++ b/src/String.c
@@ -66,7 +66,7 @@ static const char* const DECIMAL_LOOKUP =
 /* ---------------------------------------------------------------------------------------------- */
 
 #if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM) || defined(ZYAN_PPC)
-ZyanStatus ZydisStringAppendDecU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length)
+static ZyanStatus ZydisStringAppendDecU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length)
 {
     ZYAN_ASSERT(string);
     ZYAN_ASSERT(!string->vector.allocator);
@@ -110,7 +110,7 @@ ZyanStatus ZydisStringAppendDecU32(ZyanString* string, ZyanU32 value, ZyanU8 pad
 }
 #endif
 
-ZyanStatus ZydisStringAppendDecU64(ZyanString* string, ZyanU64 value, ZyanU8 padding_length)
+static ZyanStatus ZydisStringAppendDecU64(ZyanString* string, ZyanU64 value, ZyanU8 padding_length)
 {
     ZYAN_ASSERT(string);
     ZYAN_ASSERT(!string->vector.allocator);
@@ -158,7 +158,7 @@ ZyanStatus ZydisStringAppendDecU64(ZyanString* string, ZyanU64 value, ZyanU8 pad
 /* ---------------------------------------------------------------------------------------------- */
 
 #if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM) || defined(ZYAN_PPC)
-ZyanStatus ZydisStringAppendHexU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length,
+static ZyanStatus ZydisStringAppendHexU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length,
     ZyanBool force_leading_number, ZyanBool uppercase)
 {
     ZYAN_ASSERT(string);
@@ -231,7 +231,7 @@ ZyanStatus ZydisStringAppendHexU32(ZyanString* string, ZyanU32 value, ZyanU8 pad
 }
 #endif
 
-ZyanStatus ZydisStringAppendHexU64(ZyanString* string, ZyanU64 value, ZyanU8 padding_length,
+static ZyanStatus ZydisStringAppendHexU64(ZyanString* string, ZyanU64 value, ZyanU8 padding_length,
     ZyanBool force_leading_number, ZyanBool uppercase)
 {
     ZYAN_ASSERT(string);


### PR DESCRIPTION
Fix some warnings output by GCC when compiling amalgamated source:

Zydis.c:45353:12: warning: no previous declaration for ‘ZydisDecodeOperands’ [-Wmissing-declarations] 45353 | ZyanStatus ZydisDecodeOperands(const ZydisDecoder* decoder, const ZydisDecoderContext* context,
      |            ^~~~~~~~~~~~~~~~~~~
Zydis.c:52494:6: warning: no previous declaration for ‘ZydisBuildRegisterOperand’ [-Wmissing-declarations]
52494 | void ZydisBuildRegisterOperand(const ZydisEncoderOperand *user_op,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~
Zydis.c:53639:6: warning: no previous declaration for ‘ZydisFormatterBufferInit’ [-Wmissing-declarations]
53639 | void ZydisFormatterBufferInit(ZydisFormatterBuffer* buffer, char* user_buffer,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~
Zydis.c:53661:6: warning: no previous declaration for ‘ZydisFormatterBufferInitTokenized’ [-Wmissing-declarations]
53661 | void ZydisFormatterBufferInitTokenized(ZydisFormatterBuffer* buffer,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Zydis.c:54354:12: warning: no previous declaration for ‘ZydisStringAppendDecU64’ [-Wmissing-declarations]
54354 | ZyanStatus ZydisStringAppendDecU64(ZyanString* string, ZyanU64 value, ZyanU8 padding_length)
      |            ^~~~~~~~~~~~~~~~~~~~~~~
Zydis.c:54475:12: warning: no previous declaration for ‘ZydisStringAppendHexU64’ [-Wmissing-declarations]
54475 | ZyanStatus ZydisStringAppendHexU64(ZyanString* string, ZyanU64 value, ZyanU8 padding_length,
      |            ^~~~~~~~~~~~~~~~~~~~~~~