### PR TITLE
Build: fix amalgamation public header warning

### DIFF
--- a/assets/amalgamate.py
+++ b/assets/amalgamate.py
@@ -59,11 +59,11 @@ def merge_headers(
     with path.open() as f:
         lines = [x.rstrip() for x in f]
 
-    if path in covered_headers:
+    if header in covered_headers:
         return []
 
     print(f'Processing header "{header}"')
-    covered_headers.add(path)
+    covered_headers.add(header)
 
     # Print the header we emit next & the include stack (if non-root).
     include_stack = []
@@ -168,8 +168,6 @@ def main():
             covered_headers=covered_headers, 
             stack=[],
         )))
-
-    print(covered_headers)
 
     with open(OUTPUT_DIR / 'Zydis.c', 'w') as f:
         f.write('\n'.join(FILE_HEADER + merge_sources(


### PR DESCRIPTION
The previous code would mix up absolute and relative paths to determine when to print the warning about public headers first being encountered when processing the source files. This commit fixes this and thus gets rid of the incorrect warnings.