### PR TITLE
Fix the installation location of manpages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,7 +490,7 @@ if (ZYDIS_BUILD_MAN)
                 "--output-dir=${CMAKE_CURRENT_BINARY_DIR}"
                 "${CMAKE_CURRENT_SOURCE_DIR}/man/${MAN_NAME}.ronn"
         )
-        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MAN_NAME}" TYPE MAN)
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MAN_NAME}" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
     endforeach()
     add_custom_target(man ALL DEPENDS ${MAN_NAMES})
 endif ()


### PR DESCRIPTION
Hi, I am trying to make zycore-c and zydis into Fedora official repository. This PR is to change the install location of manpages of small useful CLI tools to `${CMAKE_INSTALL_MANDIR}/man1` to accomodate the common rules, which the tools will be built with the `ZYDIS_BUILD_TOOLS` option is on.