### PR TITLE
Add missing `(void)` on functions without args

### DIFF
--- a/examples/Disassemble.c
+++ b/examples/Disassemble.c
@@ -36,7 +36,7 @@
 #include <inttypes.h>
 #include <Zydis/Zydis.h>
 
-int main()
+int main(void)
 {
     ZyanU8 data[] =
     {

--- a/examples/DisassembleSimple.c
+++ b/examples/DisassembleSimple.c
@@ -33,7 +33,7 @@
 #include <inttypes.h>
 #include <Zydis/Zydis.h>
 
-int main()
+int main(void)
 {
     ZyanU8 data[] =
     {

--- a/examples/EncodeFromScratch.c
+++ b/examples/EncodeFromScratch.c
@@ -119,7 +119,7 @@ int main(void)
     ExpectSuccess(ZyanMemoryVirtualProtect(aligned, alloc_size, ZYAN_PAGE_EXECUTE_READWRITE));
 
     // Create a function pointer for our buffer.
-    typedef ZyanU64(*FnPtr)();
+    typedef ZyanU64(*FnPtr)(void);
     const FnPtr func_ptr = (FnPtr)(uintptr_t)buffer;
 
     // Call the function!

--- a/examples/EncodeMov.c
+++ b/examples/EncodeMov.c
@@ -34,7 +34,7 @@
 
 #include <Zydis/Zydis.h>
 
-int main()
+int main(void)
 {
     ZydisEncoderRequest req;
     memset(&req, 0, sizeof(req));

--- a/tools/ZydisFuzzShared.c
+++ b/tools/ZydisFuzzShared.c
@@ -412,7 +412,7 @@ void ZydisReEncodeInstruction(const ZydisDecoder *decoder, const ZydisDecodedIns
 /* Entry point                                                                                    */
 /* ============================================================================================== */
 
-int ZydisFuzzerInit()
+int ZydisFuzzerInit(void)
 {
     if (ZydisGetVersion() != ZYDIS_VERSION)
     {

--- a/tools/ZydisTestEncoderAbsolute.c
+++ b/tools/ZydisTestEncoderAbsolute.c
@@ -163,7 +163,7 @@ static ZyanBool RunTest(ZydisEncoderRequest *req, const char *test_name, ZyanU8 
     return ZYAN_TRUE;
 }
 
-static ZyanBool RunBranchingTests()
+static ZyanBool RunBranchingTests(void)
 {
     static const ZydisMnemonic instructions[] =
     {
@@ -390,7 +390,7 @@ static ZyanBool RunBranchingTests()
     return all_passed;
 }
 
-static ZyanBool RunRipRelativeTests()
+static ZyanBool RunRipRelativeTests(void)
 {
     ZydisEncoderRequest req;
     ZyanBool all_passed = ZYAN_TRUE;


### PR DESCRIPTION
Multiple functions without arguments were missing the `(void)` that prevents them from being interpreted as not having a prototype. Newer Clang versions started printing warnings for that in pedantic mode.

Corresponding Zycore PR: https://github.com/zyantific/zycore-c/pull/64/files