### PR TITLE
CMake: improve search for Zycore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ option(ZYDIS_LIBFUZZER
 
 # Dependencies
 option(ZYAN_SYSTEM_ZYCORE
-    "Use system Zycore library"
+    "Force using system installed Zycore library"
     OFF)
 set(ZYAN_ZYCORE_PATH
     "${CMAKE_CURRENT_LIST_DIR}/dependencies/zycore"
@@ -83,35 +83,62 @@ set(ZYAN_ZYCORE_PATH
 # Dependencies                                                                                    #
 # =============================================================================================== #
 
-if (ZYAN_SYSTEM_ZYCORE)
-    find_package(Zycore REQUIRED)
-else ()
-    # Try to initialize the Zycore submodule using Git
-    if (NOT EXISTS "${ZYAN_ZYCORE_PATH}/CMakeLists.txt" AND 
-        "${ZYAN_ZYCORE_PATH}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}/dependencies/zycore")
-        find_package(Git QUIET)
-        if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-            execute_process(
-                COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive 
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} 
-            )
-        endif()
+# Tries to make Zycore available.
+#
+# Priorities:
+#
+# - ZYAN_ZYCORE_PATH specified path always takes maximum precedence if it exists.
+#   - Default value is the sub-module path. So if the sub-module is present, we pick that.
+#     Allows hacking on Zydis/Zycore even if a Zydis OS package is installed.
+# - Look for a system-installed Zycore package (via find_package).
+# - If git is installed & this is a git repository, try cloning the sub-module.
+# - Give up.
+#
+# This is in a function so we can elegantly early-exit once the library is found.
+function (locate_zycore)
+    if (NOT ${ZYAN_SYSTEM_ZYCORE} AND EXISTS "${ZYAN_ZYCORE_PATH}/CMakeLists.txt")
+        message(VERBOSE "Using ZYAN_ZYCORE_PATH specified Zycore")
+        add_subdirectory(${ZYAN_ZYCORE_PATH} "zycore" EXCLUDE_FROM_ALL)
+        return ()
     endif ()
 
-    if (NOT EXISTS "${ZYAN_ZYCORE_PATH}/CMakeLists.txt")
-        message(
-            FATAL_ERROR
-            "Can't find zycore submodule. Please make sure to clone the repo recursively.\n"
-            "You can fix this by running\n"
-            "    git submodule update --init\n"
-            "or by cloning using\n"
-            "    git clone --recursive <url>\n"
-            "Alternatively, you can manually clone zycore to some path and set ZYDIS_ZYCORE_PATH."
+    if (NOT "${ZYAN_ZYCORE_PATH}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}/dependencies/zycore")
+        message(FATAL_ERROR "No CMake project found at explicitly set ZYAN_ZYCORE_PATH")
+    endif ()
+
+    find_package(Zycore QUIET)
+    if (Zycore_FOUND)
+        message(VERBOSE "Using system Zycore")
+        return ()
+    endif ()
+
+    if (ZYAN_SYSTEM_ZYCORE)
+        message(FATAL_ERROR "ZYAN_SYSTEM_ZYCORE set but no system-installed Zycore found")
+    endif ()
+
+    find_package(Git QUIET)
+    if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+        message(VERBOSE "Pulling Zycore submodule with git.")
+        execute_process(
+                COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         )
-    endif ()
+        add_subdirectory(${ZYAN_ZYCORE_PATH} "zycore" EXCLUDE_FROM_ALL)
+        return ()
+    endif()
 
-    add_subdirectory(${ZYAN_ZYCORE_PATH} "zycore" EXCLUDE_FROM_ALL)
-endif ()
+    message(
+        FATAL_ERROR
+        "Can't find Zycore. Please make sure to clone the repo recursively.\n"
+        "You can fix this by running\n"
+        "    git submodule update --init\n"
+        "or by cloning using\n"
+        "    git clone --recursive <url>\n"
+        "Alternatively, you can manually clone zycore to some path and set ZYDIS_ZYCORE_PATH."
+    )
+endfunction ()
+
+locate_zycore()
 
 # =============================================================================================== #
 # Library configuration                                                                           #


### PR DESCRIPTION
The changes in this PR should allow Zydis to find Zycore in more situations automatically. Most importantly, `find_package(Zycore)` is now something that we try automatically. This should allow distributions that ship Zycore as a separate package to do so more easily without having to delve into out CMake logic to discover the `ZYAN_SYSTEM_ZYCORE` option.

I tested:

- building a full clone with submodule
- building an incomplete clone (with and without git installed)
- fallback to system zycore (by hacking the NixOS package, with and without `-DZYAN_SYSTEM_ZYCORE`)