### PR TITLE
Fuzzing improvements and bugfixes

### DIFF
--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -4907,7 +4907,8 @@ ZyanStatus ZydisDecoderInit(ZydisDecoder* decoder, ZydisMachineMode machine_mode
         (1 << ZYDIS_DECODER_MODE_CET) |
         (1 << ZYDIS_DECODER_MODE_LZCNT) |
         (1 << ZYDIS_DECODER_MODE_TZCNT) |
-        (1 << ZYDIS_DECODER_MODE_CLDEMOTE);
+        (1 << ZYDIS_DECODER_MODE_CLDEMOTE) |
+        (1 << ZYDIS_DECODER_MODE_IPREFETCH);
 
     if (!decoder)
     {

--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -4527,6 +4527,10 @@ ZYDIS_EXPORT ZyanStatus ZydisEncoderEncodeInstructionAbsolute(ZydisEncoderReques
         }
         ZYAN_ASSERT(instruction.disp_size != 0);
         ZyanU8 disp_offset = (instruction.disp_size >> 3) + (instruction.imm_size >> 3);
+        if (instruction.encoding == ZYDIS_INSTRUCTION_ENCODING_3DNOW)
+        {
+            disp_offset += 1;
+        }
         ZYAN_ASSERT(instruction_size > disp_offset);
         ZYAN_MEMCPY((ZyanU8 *)buffer + instruction_size - disp_offset, &rip_rel, sizeof(ZyanI32));
         op_rip_rel->mem.displacement = rip_rel;

--- a/tools/ZydisDisasm.c
+++ b/tools/ZydisDisasm.c
@@ -91,7 +91,7 @@ static void PrintDisassembly(const ZydisFormatter* formatter,
     const ZydisFormatterToken* token;
 
     if (!ZYAN_SUCCESS(status = ZydisFormatterTokenizeInstruction(formatter, instruction, operands,
-        instruction->operand_count_visible, buffer, length, runtime_address, &token, NULL)))
+        instruction->operand_count_visible, buffer, length, runtime_address, &token, ZYAN_NULL)))
     {
         PrintStatusError(status, "Failed to tokenize instruction");
         exit(status);

--- a/tools/ZydisFuzzDecoder.c
+++ b/tools/ZydisFuzzDecoder.c
@@ -133,13 +133,13 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void* stream_ctx)
     // Allow the control block to artificially restrict the buffer size.
     ZyanUSize output_len = ZYAN_MIN(sizeof(format_buffer), control_block.formatter_max_len);
     ZydisFormatterFormatInstruction(&formatter, &instruction, operands,
-        instruction.operand_count_visible, format_buffer, output_len, control_block.u64, NULL);
+        instruction.operand_count_visible, format_buffer, output_len, control_block.u64, ZYAN_NULL);
 
     // Fuzz tokenizer.
     const ZydisFormatterToken* token;
     status = ZydisFormatterTokenizeInstruction(&formatter, &instruction, operands,
         instruction.operand_count_visible, format_buffer, output_len, control_block.u64, &token,
-        NULL);
+        ZYAN_NULL);
 
     // Walk tokens.
     while (ZYAN_SUCCESS(status))
@@ -163,11 +163,11 @@ int ZydisFuzzTarget(ZydisStreamRead read_fn, void* stream_ctx)
         const ZydisDecodedOperand* op = &operands[op_idx];
 
         ZydisFormatterFormatOperand(&formatter, &instruction, op, format_buffer, output_len,
-            control_block.u64, NULL);
+            control_block.u64, ZYAN_NULL);
 
         // Fuzz single operand tokenization.
         ZydisFormatterTokenizeOperand(&formatter, &instruction, op, format_buffer, output_len,
-            control_block.u64, &token, NULL);
+            control_block.u64, &token, ZYAN_NULL);
 
         // Address translation helper.
         ZyanU64 abs_addr;

--- a/tools/ZydisInfo.c
+++ b/tools/ZydisInfo.c
@@ -838,7 +838,7 @@ static void PrintDisassembly(const ZydisDecodedInstruction* instruction,
 
     PrintValueLabel("ABSOLUTE");
     if (!ZYAN_SUCCESS(status = ZydisFormatterTokenizeInstruction(&formatter, instruction, operands,
-        instruction->operand_count_visible, buffer, sizeof(buffer), 0, &token, NULL)))
+        instruction->operand_count_visible, buffer, sizeof(buffer), 0, &token, ZYAN_NULL)))
     {
         PrintStatusError(status, "Failed to tokenize instruction");
         exit(status);
@@ -847,7 +847,7 @@ static void PrintDisassembly(const ZydisDecodedInstruction* instruction,
     PrintValueLabel("RELATIVE");
     if (!ZYAN_SUCCESS(status = ZydisFormatterTokenizeInstruction(&formatter, instruction, operands,
         instruction->operand_count_visible, buffer, sizeof(buffer), ZYDIS_RUNTIME_ADDRESS_NONE,
-        &token, NULL)))
+        &token, ZYAN_NULL)))
     {
         PrintStatusError(status, "Failed to tokenize instruction");
         exit(status);

--- a/tools/ZydisTestEncoderAbsolute.c
+++ b/tools/ZydisTestEncoderAbsolute.c
@@ -443,6 +443,19 @@ static ZyanBool RunRipRelativeTests(void)
     req.operands[1].reg.value = ZYDIS_REGISTER_EBX;
     all_passed &= RunTest(&req, ZydisMnemonicGetString(req.mnemonic), 0, ZYAN_TRUE);
 
+    // AMD 3DNow!
+    ZYAN_MEMSET(&req, 0, sizeof(req));
+    req.machine_mode = ZYDIS_MACHINE_MODE_LONG_64;
+    req.mnemonic = ZYDIS_MNEMONIC_PI2FD;
+    req.operand_count = 2;
+    req.operands[0].type = ZYDIS_OPERAND_TYPE_REGISTER;
+    req.operands[0].reg.value = ZYDIS_REGISTER_MM1;
+    req.operands[1].type = ZYDIS_OPERAND_TYPE_MEMORY;
+    req.operands[1].mem.base = ZYDIS_REGISTER_RIP;
+    req.operands[1].mem.displacement = 0x66666666;
+    req.operands[1].mem.size = 8;
+    all_passed &= RunTest(&req, ZydisMnemonicGetString(req.mnemonic), 1, ZYAN_TRUE);
+
     return all_passed;
 }
 


### PR DESCRIPTION
I'm putting 3 changes in this PR because fuzzers naturally depend on bugfixes and those are one-liners anyway. Having separate pull requests would be an overkill and they would have to be merged in a specific order. I've kept one change per commit for clarity.

Changes:
- Fuzzing `ZydisEncoderEncodeInstructionAbsolute` - primary goal of this PR, doesn't need much explanation. Although `ZydisTestEncoderAbsolute` aims to cover every case some stuff went unnoticed like #463. Fuzzing is a valuable 2nd layer of testing here.
- 3DNow! handling - first and hopefully the last issue found by new fuzzing logic. 3DNow! instructions have extra opcode byte at the end and that confused logic inside `ZydisEncoderEncodeInstructionAbsolute`.
- Enable IPREFETCH mode by default - we had it documented as enabled by default while it wasn't