### PR TITLE
Formatter improvements (sizes and addresses)

### DIFF
--- a/include/Zydis/Formatter.h
+++ b/include/Zydis/Formatter.h
@@ -176,16 +176,16 @@ typedef enum ZydisFormatterProperty_
     /**
      * Controls the padding of absolute address values.
      *
-     * Pass `ZYDIS_PADDING_DISABLED` to disable padding, `ZYDIS_PADDING_AUTO` to padd all
-     * addresses to the current stack width (hexadecimal only), or any other integer value for
+     * Pass `ZYDIS_PADDING_DISABLED` to disable padding, `ZYDIS_PADDING_AUTO` to pad all
+     * addresses to the current address width (hexadecimal only), or any other integer value for
      * custom padding.
      */
     ZYDIS_FORMATTER_PROP_ADDR_PADDING_ABSOLUTE,
     /**
      * Controls the padding of relative address values.
      *
-     * Pass `ZYDIS_PADDING_DISABLED` to disable padding, `ZYDIS_PADDING_AUTO` to padd all
-     * addresses to the current stack width (hexadecimal only), or any other integer value for
+     * Pass `ZYDIS_PADDING_DISABLED` to disable padding, `ZYDIS_PADDING_AUTO` to pad all
+     * addresses to the current address width (hexadecimal only), or any other integer value for
      * custom padding.
      */
     ZYDIS_FORMATTER_PROP_ADDR_PADDING_RELATIVE,

--- a/src/FormatterBase.c
+++ b/src/FormatterBase.c
@@ -86,11 +86,16 @@ ZyanU32 ZydisFormatterHelperGetExplicitSize(const ZydisFormatter* formatter,
 
     ZYAN_ASSERT(operand->type == ZYDIS_OPERAND_TYPE_MEMORY);
     ZYAN_ASSERT((operand->mem.type == ZYDIS_MEMOP_TYPE_MEM) ||
+                (operand->mem.type == ZYDIS_MEMOP_TYPE_AGEN) ||
                 (operand->mem.type == ZYDIS_MEMOP_TYPE_VSIB));
 
     if (formatter->force_memory_size)
     {
         return operand->size;
+    }
+    else if (operand->mem.type == ZYDIS_MEMOP_TYPE_AGEN)
+    {
+        return 0;
     }
 
     if (!context->operands)

--- a/src/FormatterBase.c
+++ b/src/FormatterBase.c
@@ -235,7 +235,7 @@ ZyanStatus ZydisFormatterBasePrintAddressABS(const ZydisFormatter* formatter,
     if ((formatter->addr_padding_absolute == ZYDIS_PADDING_AUTO) &&
         (formatter->addr_base == ZYDIS_NUMERIC_BASE_HEX))
     {
-        switch (context->instruction->stack_width)
+        switch (context->instruction->address_width)
         {
         case 16:
             padding =  4;
@@ -275,7 +275,7 @@ ZyanStatus ZydisFormatterBasePrintAddressREL(const ZydisFormatter* formatter,
     if ((formatter->addr_padding_relative == ZYDIS_PADDING_AUTO) &&
         (formatter->addr_base == ZYDIS_NUMERIC_BASE_HEX))
     {
-        switch (context->instruction->stack_width)
+        switch (context->instruction->address_width)
         {
         case 16:
             padding =  4;

--- a/src/FormatterIntel.c
+++ b/src/FormatterIntel.c
@@ -426,7 +426,7 @@ ZyanStatus ZydisFormatterIntelPrintAddressMASM(const ZydisFormatter* formatter,
     if ((formatter->addr_padding_relative == ZYDIS_PADDING_AUTO) &&
         (formatter->addr_base == ZYDIS_NUMERIC_BASE_HEX))
     {
-        switch (context->instruction->stack_width)
+        switch (context->instruction->address_width)
         {
         case 16:
             padding =  4;

--- a/src/FormatterIntel.c
+++ b/src/FormatterIntel.c
@@ -201,6 +201,7 @@ ZyanStatus ZydisFormatterIntelFormatOperandMEM(const ZydisFormatter* formatter,
     ZYAN_ASSERT(context);
 
     if ((context->operand->mem.type == ZYDIS_MEMOP_TYPE_MEM) ||
+        (context->operand->mem.type == ZYDIS_MEMOP_TYPE_AGEN) ||
         (context->operand->mem.type == ZYDIS_MEMOP_TYPE_VSIB))
     {
         ZYAN_CHECK(formatter->func_print_typecast(formatter, buffer, context));


### PR DESCRIPTION
1. Replaced `stack_width` -> `address_width` to prevent trimming real values in some situation (address size overrides)
1. Print `agen` sizes (in forced mode only) -> affects `lea` and some `bnd*` instructions, `mib` behavior unchanged because we don't have standardized names for such sizes anyway