### PR TITLE
Decoder: add missing underscore for `ZydisDecodedInstructionRawEvex`

### DIFF
--- a/include/Zydis/DecoderTypes.h
+++ b/include/Zydis/DecoderTypes.h
@@ -865,7 +865,7 @@ typedef struct ZydisDecodedInstructionRawVex_
 /**
  * Detailed info about the `EVEX` prefix.
  */
-typedef struct ZydisDecodedInstructionRawEvex
+typedef struct ZydisDecodedInstructionRawEvex_
 {
     /**
      * Extension of the `ModRM.reg` field (inverted).


### PR DESCRIPTION
@can1357 noticed that we were missing an underscore after `ZydisDecodedInstructionRawEvex`, this fixed that.