### PR TITLE
Use alias targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,9 @@ else ()
     add_library("Zydis" STATIC)
     target_compile_definitions("Zydis" PUBLIC "ZYDIS_STATIC_BUILD")
 endif ()
+add_library("Zydis::Zydis" ALIAS "Zydis")
 
-target_link_libraries("Zydis" PUBLIC "Zycore")
+target_link_libraries("Zydis" PUBLIC "Zycore::Zycore")
 target_include_directories("Zydis"
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
Complements and depends on https://github.com/zyantific/zycore-c/pull/71.
Fixes build with "system" zycore.