### PR TITLE
Adds include for ZYAN_BITS_TO_REPRESENT in generated headers.

### DIFF
--- a/include/Zydis/Generated/EnumISAExt.h
+++ b/include/Zydis/Generated/EnumISAExt.h
@@ -1,3 +1,4 @@
+#include "Zycore/Defines.h"
 /**
  * Defines the `ZydisISAExt` enum.
  */

--- a/include/Zydis/Generated/EnumISASet.h
+++ b/include/Zydis/Generated/EnumISASet.h
@@ -1,3 +1,4 @@
+#include "Zycore/Defines.h"
 /**
  * Defines the `ZydisISASet` enum.
  */

--- a/include/Zydis/Generated/EnumInstructionCategory.h
+++ b/include/Zydis/Generated/EnumInstructionCategory.h
@@ -1,3 +1,4 @@
+#include "Zycore/Defines.h"
 /**
  * Defines the `ZydisInstructionCategory` enum.
  */

--- a/include/Zydis/Generated/EnumMnemonic.h
+++ b/include/Zydis/Generated/EnumMnemonic.h
@@ -1,3 +1,4 @@
+#include "Zycore/Defines.h"
 /**
  * Defines the `ZydisMnemonic` enum.
  */

--- a/include/Zydis/Generated/EnumRegister.h
+++ b/include/Zydis/Generated/EnumRegister.h
@@ -1,3 +1,4 @@
+#include "Zycore/Defines.h"
 /**
  * Defines the `ZydisRegister` enum.
  */


### PR DESCRIPTION
I was having a few issues compiling the project in bazel.
I couldn't find where these headers are generated but I'm happy to update that as well.