### PR TITLE
Bump version number to 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
     cmake_policy(SET CMP0091 NEW)
 endif ()
 
-project(Zydis VERSION 4.0.0.0 LANGUAGES C)
+project(Zydis VERSION 5.0.0.0 LANGUAGES C)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/Doxyfile
+++ b/Doxyfile
@@ -2,7 +2,7 @@
 # per line (i.e. do not split long lines with '\'), and only use '=' to set values
 
 PROJECT_NAME = Zydis
-PROJECT_NUMBER = v4.0.0
+PROJECT_NUMBER = v5.0.0
 OUTPUT_DIRECTORY = ./doc
 INPUT = ./include ./README.md ./files.dox
 JAVADOC_AUTOBRIEF = YES

--- a/include/Zydis/Zydis.h
+++ b/include/Zydis/Zydis.h
@@ -86,7 +86,7 @@ extern "C" {
 /**
  * A macro that defines the zydis version.
  */
-#define ZYDIS_VERSION (ZyanU64)0x0005000000000000
+#define ZYDIS_VERSION 0x0005000000000000ULL
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Helper macros                                                                                  */
@@ -97,28 +97,28 @@ extern "C" {
  *
  * @param   version The zydis version value
  */
-#define ZYDIS_VERSION_MAJOR(version) (ZyanU16)(((version) & 0xFFFF000000000000) >> 48)
+#define ZYDIS_VERSION_MAJOR(version) (((version) & 0xFFFF000000000000) >> 48)
 
 /**
  * Extracts the minor-part of the zydis version.
  *
  * @param   version The zydis version value
  */
-#define ZYDIS_VERSION_MINOR(version) (ZyanU16)(((version) & 0x0000FFFF00000000) >> 32)
+#define ZYDIS_VERSION_MINOR(version) (((version) & 0x0000FFFF00000000) >> 32)
 
 /**
  * Extracts the patch-part of the zydis version.
  *
  * @param   version The zydis version value
  */
-#define ZYDIS_VERSION_PATCH(version) (ZyanU16)(((version) & 0x00000000FFFF0000) >> 16)
+#define ZYDIS_VERSION_PATCH(version) (((version) & 0x00000000FFFF0000) >> 16)
 
 /**
  * Extracts the build-part of the zydis version.
  *
  * @param   version The zydis version value
  */
-#define ZYDIS_VERSION_BUILD(version) (ZyanU16)((version) & 0x000000000000FFFF)
+#define ZYDIS_VERSION_BUILD(version) ((version) & 0x000000000000FFFF)
 
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/include/Zydis/Zydis.h
+++ b/include/Zydis/Zydis.h
@@ -86,7 +86,7 @@ extern "C" {
 /**
  * A macro that defines the zydis version.
  */
-#define ZYDIS_VERSION (ZyanU64)0x0004000000000000
+#define ZYDIS_VERSION (ZyanU64)0x0005000000000000
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Helper macros                                                                                  */

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'Zydis',
   'c',
-  version: '4.0.0',
+  version: '5.0.0',
   license: 'MIT',
   license_files: 'LICENSE',
   meson_version: '>=1.3',

--- a/resources/VersionInfo.rc
+++ b/resources/VersionInfo.rc
@@ -27,8 +27,8 @@
 #include "winres.h"
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,0,0,0
- PRODUCTVERSION 4,0,0,0
+ FILEVERSION 5,0,0,0
+ PRODUCTVERSION 5,0,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -45,12 +45,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "zyantific"
             VALUE "FileDescription", "Zyan Disassembler Library"
-            VALUE "FileVersion", "4.0.0.0"
+            VALUE "FileVersion", "5.0.0.0"
             VALUE "InternalName", "Zydis"
             VALUE "LegalCopyright", "Copyright \xA9 2014-2024 by zyantific.com"
             VALUE "OriginalFilename", "Zydis.dll"
             VALUE "ProductName", "Zyan Disassembler Library"
-            VALUE "ProductVersion", "4.0.0.0"
+            VALUE "ProductVersion", "5.0.0.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Since we already introduced breaking API changes, so there should be a way to detect those changes for users.