### PR TITLE
Fix ATT Formatter VSIB extra operand-size suffix

### DIFF
--- a/src/FormatterATT.c
+++ b/src/FormatterATT.c
@@ -302,8 +302,7 @@ ZyanStatus ZydisFormatterATTPrintMnemonic(const ZydisFormatter* formatter,
     {
         const ZydisDecodedOperand* const operand = &context->operands[i];
         if ((operand->type == ZYDIS_OPERAND_TYPE_MEMORY) &&
-            ((operand->mem.type == ZYDIS_MEMOP_TYPE_MEM) ||
-             (operand->mem.type == ZYDIS_MEMOP_TYPE_VSIB)))
+            (operand->mem.type == ZYDIS_MEMOP_TYPE_MEM))
         {
             size = ZydisFormatterHelperGetExplicitSize(formatter, context, operand);
             break;


### PR DESCRIPTION
As for now, all VSIB instructions have explicit operand size suffix in the mnemonic (thanks @mappzor for the check).
Yet, the ATT Formatter currently adds an explicit size suffix for the VSIB operand and create invalid disassembly (e.g. `vpgatherqqq`).

This PR removes the `ZYDIS_MEMOP_TYPE_VSIB` from the memory operand types that are searched for the explicit size suffix.

Closes #550.