### PR TITLE
Update Zydis with `ZYAN_ARCHITECTURE_WIDTH` macro

### DIFF
--- a/src/String.c
+++ b/src/String.c
@@ -65,7 +65,7 @@ static const char* const DECIMAL_LOOKUP =
 /* Decimal                                                                                        */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM) || defined(ZYAN_PPC)
+#if ZYAN_ARCHITECTURE_WIDTH != 64
 static ZyanStatus ZydisStringAppendDecU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length)
 {
     ZYAN_ASSERT(string);
@@ -157,7 +157,7 @@ static ZyanStatus ZydisStringAppendDecU64(ZyanString* string, ZyanU64 value, Zya
 /* Hexadecimal                                                                                    */
 /* ---------------------------------------------------------------------------------------------- */
 
-#if defined(ZYAN_X86) || defined(ZYAN_ARM) || defined(ZYAN_EMSCRIPTEN) || defined(ZYAN_WASM) || defined(ZYAN_PPC)
+#if ZYAN_ARCHITECTURE_WIDTH != 64
 static ZyanStatus ZydisStringAppendHexU32(ZyanString* string, ZyanU32 value, ZyanU8 padding_length,
     ZyanBool force_leading_number, ZyanBool uppercase)
 {
@@ -322,7 +322,7 @@ ZyanStatus ZydisStringAppendDecU(ZyanString* string, ZyanU64 value, ZyanU8 paddi
         ZYAN_CHECK(ZydisStringAppend(string, prefix));
     }
 
-#if defined(ZYAN_X64) || defined(ZYAN_AARCH64) || defined(ZYAN_PPC64) || defined(ZYAN_RISCV64) || defined(ZYAN_LOONGARCH)
+#if ZYAN_ARCHITECTURE_WIDTH == 64
     ZYAN_CHECK(ZydisStringAppendDecU64(string, value, padding_length));
 #else
     if (value & 0xFFFFFFFF00000000)
@@ -348,7 +348,7 @@ ZyanStatus ZydisStringAppendHexU(ZyanString* string, ZyanU64 value, ZyanU8 paddi
         ZYAN_CHECK(ZydisStringAppend(string, prefix));
     }
 
-#if defined(ZYAN_X64) || defined(ZYAN_AARCH64) || defined(ZYAN_PPC64) || defined(ZYAN_RISCV64) || defined(ZYAN_LOONGARCH)
+#if ZYAN_ARCHITECTURE_WIDTH == 64
     ZYAN_CHECK(ZydisStringAppendHexU64(string, value, padding_length, force_leading_number,
         uppercase));
 #else


### PR DESCRIPTION
Functions were not defined for system Z (s390 architecture) in some cases. Added macro-check for relevant functions for s390 host.
Changes tested on pull request : https://github.com/rizinorg/rizin/pull/5164
S390 host test result for rizin using Zydis plugin : https://app.travis-ci.com/github/rizinorg/rizin/jobs/633033533