### PR TITLE
Fix ZydisEmitUInt with size 1 on big endian

### DIFF
--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -3382,11 +3382,11 @@ static ZyanStatus ZydisEmitUInt(ZyanU64 data, ZyanU8 size, ZydisEncoderBuffer *b
 
     // The size variable is not passed on purpose to allow the compiler
     // to generate better code with a known size at compile time.
+#if ZYAN_ENDIAN == ZYAN_LITTLE_ENDIAN
     if (size == 1)
     {
         ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 1);
     }
-#if ZYAN_ENDIAN == ZYAN_LITTLE_ENDIAN
     else if (size == 2)
     {
         ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 2);
@@ -3400,6 +3400,11 @@ static ZyanStatus ZydisEmitUInt(ZyanU64 data, ZyanU8 size, ZydisEncoderBuffer *b
         ZYAN_MEMCPY(buffer->buffer + buffer->offset, &data, 8);
     }
 #else
+    if (size == 1)
+    {
+        ZyanU8 value = (ZyanU8)data;
+        ZYAN_MEMCPY(buffer->buffer + buffer->offset, &value, 1);
+    }
     else if (size == 2)
     {
         ZyanU16 value = ZYAN_BYTESWAP16((ZyanU16)data);


### PR DESCRIPTION
Even if only a single byte is copied, that byte will not be at the lowest address of a ZyanU64 value, so a cast to ZyanU8 is still necessary, only without a byte swap.

Tested on OpenBSD/sparc64. More changes will be necessary to get zydis to work there properly, in particular the packing of `ZydisShortString` causes segfaults. But the approach suggested in #263 is probably the best way to fix it for sparc since it has very strict alignment requirements.