### PR TITLE
Encoder: fix off-by-one in runtime address overflow check

### DIFF
--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -4760,7 +4760,7 @@ ZYDIS_EXPORT ZyanStatus ZydisEncoderEncodeInstructionAbsolute(ZydisEncoderReques
                         continue;
                     }
                     ZyanU8 predicted_size = base_size + extra_length;
-                    if (runtime_address > ZYAN_UINT64_MAX - predicted_size + 1)
+                    if (runtime_address > ZYAN_UINT64_MAX - predicted_size)
                     {
                         continue;
                     }
@@ -4813,7 +4813,7 @@ ZYDIS_EXPORT ZyanStatus ZydisEncoderEncodeInstructionAbsolute(ZydisEncoderReques
                             (rel_info->size[asz_index][2] == 0) &&
                             !rel_info->accepts_branch_hints);
                 ZyanU8 predicted_size = rel_info->size[asz_index][0] + extra_length;
-                if (runtime_address > ZYAN_UINT64_MAX - predicted_size + 1)
+                if (runtime_address > ZYAN_UINT64_MAX - predicted_size)
                 {
                     return ZYAN_STATUS_INVALID_ARGUMENT;
                 }
@@ -4855,7 +4855,7 @@ ZYDIS_EXPORT ZyanStatus ZydisEncoderEncodeInstructionAbsolute(ZydisEncoderReques
     if (op_rip_rel)
     {
         ZyanUSize instruction_size = *length;
-        if (runtime_address > ZYAN_UINT64_MAX - instruction_size + 1)
+        if (runtime_address > ZYAN_UINT64_MAX - instruction_size)
         {
             return ZYAN_STATUS_INVALID_ARGUMENT;
         }


### PR DESCRIPTION
## Bug

`ZydisEncoderEncodeInstructionAbsolute` (in `src/Encoder.c`) guards against
`runtime_address + predicted_size` overflowing `ZYAN_UINT64_MAX` before
computing the relative offset. The current check is:

```c
if (runtime_address > ZYAN_UINT64_MAX - predicted_size + 1)
{
    /* reject */
}
```

The intent is clearly to forbid inputs that would wrap, but the `+ 1` makes
the guard too permissive by one. With

```
runtime_address == ZYAN_UINT64_MAX - predicted_size + 1
```

the comparison evaluates to `false`, the function continues, and the very
next statement does `runtime_address + predicted_size`, which wraps to `0`.
The resulting `rip_rel = absolute_address - 0` then encodes a displacement
that the guard was specifically intended to reject.

The same off-by-one appears at three sites in this function:

- `src/Encoder.c:4763` (ZYDIS_SIZE_HINT_NONE / OSZ branch, per-size loop)
- `src/Encoder.c:4816` (ZYDIS_SIZE_HINT_ASZ branch)
- `src/Encoder.c:4858` (RIP/EIP-relative memory operand handling)

The correct check, matching the standard `a + b` overflow idiom for
unsigned types, is `runtime_address > ZYAN_UINT64_MAX - size` (no `+ 1`).
The boundary `runtime_address == ZYAN_UINT64_MAX - size` then evaluates
`sum == ZYAN_UINT64_MAX`, which is the largest representable value and
does not overflow.

## Reproducer

```c
ZydisEncoderRequest req = { 0 };
req.machine_mode = ZYDIS_MACHINE_MODE_LONG_64;
req.mnemonic = ZYDIS_MNEMONIC_MOV;
req.operand_count = 2;
req.operands[0].type = ZYDIS_OPERAND_TYPE_REGISTER;
req.operands[0].reg.value = ZYDIS_REGISTER_RAX;
req.operands[1].type = ZYDIS_OPERAND_TYPE_MEMORY;
req.operands[1].mem.base = ZYDIS_REGISTER_RIP;
req.operands[1].mem.displacement = 0x100;
req.operands[1].mem.size = 8;

ZyanU8 buf[ZYDIS_MAX_INSTRUCTION_LENGTH];
ZyanUSize len = sizeof(buf);

/* MOV r64, [rip + disp32] encodes to 7 bytes. The off-by-one boundary
 * is runtime_address == UINT64_MAX - 7 + 1 == 0xFFFFFFFFFFFFFFF9. */
ZydisEncoderEncodeInstructionAbsolute(&req, buf, &len, 0xFFFFFFFFFFFFFFF9ULL);
```

Built with `-fsanitize=unsigned-integer-overflow`, the unpatched code
trips the sanitizer on `runtime_address + instruction_size`:

```
runtime error: unsigned integer overflow:
  18446744073709551609 + 7 cannot be represented in type 'ZyanU64'
```

After the fix, that same call is correctly rejected with
`ZYAN_STATUS_INVALID_ARGUMENT` before the wrapping addition is reached.

## Fix

The fix is local to `ZydisEncoderEncodeInstructionAbsolute`; it removes the
spurious `+ 1` from the three overflow guards. No other behaviour changes.

## Testing

- `tests/regression.py test` — all decode regression cases still pass.
- `tests/regression_encoder.py` (re-encoding, encoder, absolute-address
  encoder suites) — all encoder regression cases still pass.
- The reproducer above no longer produces a UBSan unsigned-overflow
  diagnostic with the fix applied.