### PR TITLE
FormatterBuffer: reject GetToken on non-token-list buffers

### DIFF
--- a/src/FormatterBuffer.c
+++ b/src/FormatterBuffer.c
@@ -78,6 +78,11 @@ ZyanStatus ZydisFormatterBufferGetToken(const ZydisFormatterBuffer* buffer,
         return ZYAN_STATUS_INVALID_ARGUMENT;
     }
 
+    if (!buffer->is_token_list)
+    {
+        return ZYAN_STATUS_INVALID_OPERATION;
+    }
+
     *token = ((ZydisFormatterTokenConst*)buffer->string.vector.data - 1);
     if ((*token)->type == ZYDIS_TOKEN_INVALID)
     {


### PR DESCRIPTION
## Bug

`ZydisFormatterBufferGetToken` performs an out-of-bounds read on
`buffer->string.vector.data - sizeof(ZydisFormatterToken)` whenever it
is invoked on a buffer that was initialised for plain-string formatting
rather than for a token list.

Relevant code (`src/FormatterBuffer.c:73-88`):

```c
ZyanStatus ZydisFormatterBufferGetToken(const ZydisFormatterBuffer* buffer,
    ZydisFormatterTokenConst** token)
{
    if (!buffer || !token)
    {
        return ZYAN_STATUS_INVALID_ARGUMENT;
    }

    *token = ((ZydisFormatterTokenConst*)buffer->string.vector.data - 1);
    if ((*token)->type == ZYDIS_TOKEN_INVALID)
    {
        return ZYAN_STATUS_INVALID_OPERATION;
    }

    return ZYAN_STATUS_SUCCESS;
}
```

`ZydisFormatterBufferInit` (`src/Formatter.c:58-78`) sets
`buffer->string.vector.data` to the start of the user-supplied output
buffer, so `(ZydisFormatterTokenConst*)buffer->string.vector.data - 1`
points two bytes BEFORE that buffer. The function then dereferences
that pointer through `(*token)->type`, and if the byte happens not to
match `ZYDIS_TOKEN_INVALID` (zero) it returns `ZYAN_STATUS_SUCCESS`
with the OOB pointer in `*token`, which leads to further OOB accesses
when the caller hands the pointer to `ZydisFormatterTokenGetValue` or
`ZydisFormatterTokenNext`.

The sibling helper `ZydisFormatterBufferGetString` already guards its
token-header access with `if (buffer->is_token_list && ...)`; this
function is missing the same guard.

## Reproducer

```c
#include <stdio.h>
#include <string.h>
#include <Zydis/Zydis.h>
#include <Zycore/Vector.h>
#include <Zycore/String.h>

int main(void)
{
    static char arena[64];
    memset(arena, 0xCC, sizeof(arena));
    char* user_buffer = &arena[16];
    user_buffer[0] = '\0';

    ZydisFormatterBuffer buf;
    memset(&buf, 0, sizeof(buf));
    buf.is_token_list              = ZYAN_FALSE;
    buf.string.flags               = ZYAN_STRING_HAS_FIXED_CAPACITY;
    buf.string.vector.element_size = sizeof(char);
    buf.string.vector.size         = 1;
    buf.string.vector.capacity     = 48;
    buf.string.vector.data         = user_buffer;

    ZydisFormatterTokenConst* tok = NULL;
    ZyanStatus s = ZydisFormatterBufferGetToken(&buf, &tok);
    printf(\"GetToken=0x%08x *token=%p (delta=%td)\n\",
           (unsigned)s, (void*)tok, (char*)tok - user_buffer);
    return 0;
}
```

Before this patch:

```
GetToken=0x00100000 *token=0x1009b000e (delta=-2)
```

The function returns `ZYAN_STATUS_SUCCESS`, and `*token` points two
bytes before the caller's buffer, where the sentinel `0xCC` byte was
read as the token type. Any follow-up call such as
`ZydisFormatterTokenGetValue(tok, ...)` then reads more bytes from
before the buffer.

After this patch:

```
GetToken=0x80100005 *token=(nil) (delta=...)
```

`ZYAN_STATUS_INVALID_OPERATION` is returned and the OOB pointer is
never produced.

## Fix

Add the `is_token_list` early-exit to `ZydisFormatterBufferGetToken`,
matching the guard already used in `ZydisFormatterBufferGetString`.
The fix is local to the callee; no callers change. The repository's
regression suite (`python3 tests/regression.py test ./build/ZydisInfo`)
still reports `ALL TESTS PASSED`.