### PR TITLE
String: avoid double-append in ZydisStringAppendDecU on 32-bit hosts

### DIFF
--- a/src/String.c
+++ b/src/String.c
@@ -329,7 +329,10 @@ ZyanStatus ZydisStringAppendDecU(ZyanString* string, ZyanU64 value, ZyanU8 paddi
     {
         ZYAN_CHECK(ZydisStringAppendDecU64(string, value, padding_length));
     }
-    ZYAN_CHECK(ZydisStringAppendDecU32(string, (ZyanU32)value, padding_length));
+    else
+    {
+        ZYAN_CHECK(ZydisStringAppendDecU32(string, (ZyanU32)value, padding_length));
+    }
 #endif
 
     if (suffix)


### PR DESCRIPTION
## Summary

`ZydisStringAppendDecU` in `src/String.c` has a missing `else` on the
non-64-bit-architecture code path. When `ZYAN_ARCHITECTURE_WIDTH != 64`
and the input value has any of its upper 32 bits set, the function ends
up calling **both** `ZydisStringAppendDecU64` and
`ZydisStringAppendDecU32`, appending the value twice to the destination
string.

The sibling `ZydisStringAppendHexU` (just below it in the same file)
already uses the `if (… high bits …) { … U64 …} else { … U32 …}` shape,
so this is clearly an oversight in the decimal version.

## Bug

`src/String.c` (current `master`, line 325-333):

```c
#if ZYAN_ARCHITECTURE_WIDTH == 64
    ZYAN_CHECK(ZydisStringAppendDecU64(string, value, padding_length));
#else
    if (value & 0xFFFFFFFF00000000)
    {
        ZYAN_CHECK(ZydisStringAppendDecU64(string, value, padding_length));
    }
    ZYAN_CHECK(ZydisStringAppendDecU32(string, (ZyanU32)value, padding_length));
#endif
```

On a 32-bit build (e.g. `-m32`, ARM32, WASM32, i386 kernels), with
`value = 0x1_0000_0000ULL`:

* `ZydisStringAppendDecU64` writes `"4294967296"` (10 chars).
* Control falls through and `ZydisStringAppendDecU32(string, (ZyanU32)value, …)` is
  called with the truncated `(ZyanU32)0x1_0000_0000 == 0`, which then
  writes an extra `"0"` to the destination.

Final string: `"42949672960"` instead of `"4294967296"`.

For `UINT64_MAX` the output is `"184467440737095516154294967295"` (30 chars)
instead of `"18446744073709551615"` (20 chars).

## Reproducer

Mirroring the exact logic of the two helpers and the buggy dispatch,
the standalone reproducer below makes the corruption visible without
needing to cross-compile zydis to 32-bit:

```
buggy(0x1_0000_0000) value=0x0000000100000000 rc=0 out="42949672960" len=11
fixed(0x1_0000_0000) value=0x0000000100000000 rc=0 out="4294967296"  len=10
buggy(UINT64_MAX)    value=0xffffffffffffffff rc=0 out="184467440737095516154294967295" len=30
fixed(UINT64_MAX)    value=0xffffffffffffffff rc=0 out="18446744073709551615" len=20
buggy(12345)         value=0x0000000000003039 rc=0 out="12345"       len=5
fixed(12345)         value=0x0000000000003039 rc=0 out="12345"       len=5
```

(Small values never enter the high-bits branch, so they're unaffected
on either side — only values that don't fit in 32 bits trigger the bug.)

Concrete impact on a real Zydis user on a 32-bit host:

* `ZydisFormatterFormatInstruction` output is silently corrupted whenever
  the formatter renders a >32-bit decimal value (for example a
  kernel-style absolute address with `addr_base` set to
  `ZYDIS_NUMERIC_BASE_DEC`).
* The buffer is consumed roughly 2× the expected width, which can turn
  into a spurious `ZYAN_STATUS_INSUFFICIENT_BUFFER_SIZE` for callers
  sizing their buffer around the documented maximum decimal width.

## Fix

Add the missing `else` so exactly one of the two helpers runs, matching
`ZydisStringAppendHexU` directly below. The change is local to the
callee, one file, three added lines plus a brace, no behavioral change
on 64-bit (the `#if ZYAN_ARCHITECTURE_WIDTH == 64` branch is unchanged)
and no API change.

## Build / test

* `cmake -B build && make -C build Zydis` builds clean (warning-free).
* Standalone reproducer (mirroring the two helpers and the dispatch
  exactly) demonstrates the corrupted output before the patch and the
  expected single decimal representation after.