### PR TITLE
Decoder: copy offset/size from the matching raw immediate

### DIFF
--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -1964,8 +1964,8 @@ static ZyanStatus ZydisDecodeOperands(const ZydisDecoder* decoder, const ZydisDe
             {
                 operands[i].imm.value.u = instruction->raw.imm[imm_id].value.u;
             }
-            operands[i].imm.offset = instruction->raw.imm->offset;
-            operands[i].imm.size = instruction->raw.imm->size;
+            operands[i].imm.offset = instruction->raw.imm[imm_id].offset;
+            operands[i].imm.size = instruction->raw.imm[imm_id].size;
             operands[i].imm.is_signed = instruction->raw.imm[imm_id].is_signed;
             operands[i].imm.is_address = instruction->raw.imm[imm_id].is_address;
             operands[i].imm.is_relative = instruction->raw.imm[imm_id].is_relative;


### PR DESCRIPTION
## Bug

`ZydisDecodeOperands` in `src/Decoder.c` walks the operand list with an `imm_id` counter so that the second immediate (index 1) of multi-immediate instructions is read from `instruction->raw.imm[imm_id]`. The block that populates `operands[i].imm` at src/Decoder.c:1955-1971 does this for every field except `.offset` and `.size`, which use the bare `instruction->raw.imm->offset` / `->size`. Since `raw.imm` is an array of two elements, that expression always reads element 0, so the second decoded immediate inherits the offset and size of the first.

Concretely (lines 1965-1971 before the fix):

```c
operands[i].imm.value.u   = instruction->raw.imm[imm_id].value.u;
operands[i].imm.offset    = instruction->raw.imm->offset;     // always [0]
operands[i].imm.size      = instruction->raw.imm->size;       // always [0]
operands[i].imm.is_signed = instruction->raw.imm[imm_id].is_signed;
```

`ZydisDecodedOperandImm.offset` is documented (`include/Zydis/DecoderTypes.h:203-211`) as the offset of this immediate relative to the start of the instruction, and `.size` as its physical size in bits. With the bug, downstream code that uses these to slice immediates out of the instruction byte stream gets the wrong window for the second immediate.

## Reproducer

`ENTER 0x1234, 0x56` encodes as `C8 34 12 56`. Raw layout is `imm[0] = imm16 @ offset 1`, `imm[1] = imm8 @ offset 3`.

```c
const ZyanU8 bytes[] = { 0xC8, 0x34, 0x12, 0x56 };
ZydisDecoder decoder;
ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
ZydisDecodedInstruction insn;
ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
ZydisDecoderDecodeFull(&decoder, bytes, sizeof(bytes), &insn, operands);
```

Before the fix:

```
imm[0] value=0x1234 offset=1 size=16
imm[1] value=0x56   offset=1 size=16   <-- wrong; raw.imm[1] is offset=3 size=8
raw.imm[0] value=0x1234 offset=1 size=16
raw.imm[1] value=0x56   offset=3 size=8
```

After the fix:

```
imm[0] value=0x1234 offset=1 size=16
imm[1] value=0x56   offset=3 size=8
```

## Fix

Index both fields by `imm_id` so they match the rest of the assignment block:

```c
operands[i].imm.offset = instruction->raw.imm[imm_id].offset;
operands[i].imm.size   = instruction->raw.imm[imm_id].size;
```

The fix is local to the callee. No public API or behavior change for instructions with a single immediate (`imm_id == 0`).

## Test evidence

- `python3 tests/regression.py test build/ZydisInfo` → `ALL TESTS PASSED.`
- The reproducer above now reports `imm[1] offset=3 size=8`, matching `raw.imm[1]`.