### PR TITLE
Formatter: fix inverted post_operand status check

### DIFF
--- a/src/FormatterATT.c
+++ b/src/FormatterATT.c
@@ -152,7 +152,7 @@ ZyanStatus ZydisFormatterATTFormatInstruction(const ZydisFormatter* formatter,
                 ZYAN_CHECK(ZydisFormatterBufferRestore(buffer, buffer_state));
                 continue;
             }
-            if (ZYAN_SUCCESS(status))
+            if (!ZYAN_SUCCESS(status))
             {
                 return status;
             }

--- a/src/FormatterIntel.c
+++ b/src/FormatterIntel.c
@@ -154,7 +154,7 @@ ZyanStatus ZydisFormatterIntelFormatInstruction(const ZydisFormatter* formatter,
                 ZYAN_CHECK(ZydisFormatterBufferRestore(buffer, buffer_state));
                 continue;
             }
-            if (ZYAN_SUCCESS(status))
+            if (!ZYAN_SUCCESS(status))
             {
                 return status;
             }


### PR DESCRIPTION
The check after `func_post_operand` in `ZydisFormatterATTFormatInstruction`
and `ZydisFormatterIntelFormatInstruction` has its polarity inverted: it
returns when the callback reports success, so a user-installed callback
silently abandons the operand loop after the first operand. Match the
`!ZYAN_SUCCESS` form used by the `func_pre_operand` and operand-format
checks just above in the same loop.