### PR TITLE
Formatter: handle FAR/ABSOLUTE in print_branch_size switch

### DIFF
--- a/src/FormatterATT.c
+++ b/src/FormatterATT.c
@@ -354,6 +354,8 @@ ZyanStatus ZydisFormatterATTPrintMnemonic(const ZydisFormatter* formatter,
         switch (context->instruction->meta.branch_type)
         {
         case ZYDIS_BRANCH_TYPE_NONE:
+        case ZYDIS_BRANCH_TYPE_FAR:
+        case ZYDIS_BRANCH_TYPE_ABSOLUTE:
             break;
         case ZYDIS_BRANCH_TYPE_SHORT:
             return ZydisStringAppendShortCase(&buffer->string, &STR_SHORT,

--- a/src/FormatterIntel.c
+++ b/src/FormatterIntel.c
@@ -319,6 +319,7 @@ ZyanStatus ZydisFormatterIntelPrintMnemonic(const ZydisFormatter* formatter,
         switch (context->instruction->meta.branch_type)
         {
         case ZYDIS_BRANCH_TYPE_NONE:
+        case ZYDIS_BRANCH_TYPE_ABSOLUTE:
             break;
         case ZYDIS_BRANCH_TYPE_SHORT:
             return ZydisStringAppendShortCase(&buffer->string, &STR_SHORT,


### PR DESCRIPTION
The `print_branch_size` switch in `ZydisFormatterATTPrintMnemonic` and
`ZydisFormatterIntelPrintMnemonic` only covers `NONE`/`SHORT`/`NEAR`. A
`FAR` branch (ATT) or an `ABSOLUTE` branch (both formatters, e.g. APX
`JMPABS`) hits the `default` and the formatter returns
`ZYAN_STATUS_INVALID_ARGUMENT`, leaving the buffer at just the mnemonic
(`ljmp`, `lret`, `jmpabs`) with the operands dropped.