### PR TITLE
truncate 32-bit relative branch target in ZydisCalcAbsoluteAddress

### DIFF
--- a/src/Utils.c
+++ b/src/Utils.c
@@ -110,6 +110,10 @@ ZyanStatus ZydisCalcAbsoluteAddress(const ZydisDecodedInstruction* instruction,
                 {
                     *result_address &= 0xFFFF;
                 }
+                else if (instruction->operand_width == 32)
+                {
+                    *result_address &= 0xFFFFFFFF;
+                }
                 break;
             case ZYDIS_MACHINE_MODE_LONG_64:
                 break;


### PR DESCRIPTION
Found while fuzzing ZydisCalcAbsoluteAddress with high runtime
addresses. For a 32-bit-operand near branch in 16/32-bit modes the
result is never truncated to the IP width, so a rel32 at the top of
the 4 GiB space (rip 0xFFFFFFF0) returns 0x100000015 instead of the
wrapped EIP 0x15. The 16-bit arm already masks to 0xFFFF; do the
same for 32-bit.