### PR TITLE
Encoder: bound operand count in DecodedInstructionToEncoderRequest

### DIFF
--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -4883,7 +4883,8 @@ ZYDIS_EXPORT ZyanStatus ZydisEncoderDecodedInstructionToEncoderRequest(
         ZyanU8 operand_count_visible, ZydisEncoderRequest *request)
 {
     if (!instruction || !request || (operand_count_visible && !operands) ||
-        operand_count_visible != instruction->operand_count_visible)
+        operand_count_visible != instruction->operand_count_visible ||
+        operand_count_visible > ZYDIS_ENCODER_MAX_OPERANDS)
     {
         return ZYAN_STATUS_INVALID_ARGUMENT;
     }


### PR DESCRIPTION
ZydisEncoderDecodedInstructionToEncoderRequest writes operand_count_visible operands into the fixed request->operands[ZYDIS_ENCODER_MAX_OPERANDS] array but only validates the count against instruction->operand_count_visible, never the array bound. A caller-supplied ZydisDecodedInstruction with operand_count_visible > 5 then overruns the array and writes past the request struct. Reject it up front, matching the cap ZydisEncoderCheckRequestSanity already enforces on request->operand_count.