### PR TITLE
Formatter: keep disp_padding preset when set to PADDING_AUTO

### DIFF
--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -239,7 +239,8 @@ ZyanStatus ZydisFormatterSetProperty(ZydisFormatter* formatter, ZydisFormatterPr
     }
     case ZYDIS_FORMATTER_PROP_DISP_PADDING:
     {
-        if (value > 0xFF)
+        // Unlike imm/addr padding, displacement padding does not support `ZYDIS_PADDING_AUTO`
+        if (((ZydisPadding)value == ZYDIS_PADDING_AUTO) || (value > 0xFF))
         {
             return ZYAN_STATUS_INVALID_ARGUMENT;
         }

--- a/src/Formatter.c
+++ b/src/Formatter.c
@@ -239,15 +239,7 @@ ZyanStatus ZydisFormatterSetProperty(ZydisFormatter* formatter, ZydisFormatterPr
     }
     case ZYDIS_FORMATTER_PROP_DISP_PADDING:
     {
-        if ((ZydisPadding)value == ZYDIS_PADDING_AUTO)
-        {
-            if ((ZyanUSize)formatter->style > ZYDIS_FORMATTER_STYLE_MAX_VALUE)
-            {
-                return ZYAN_STATUS_INVALID_ARGUMENT;
-            }
-            formatter->disp_padding = FORMATTER_PRESETS[formatter->style]->disp_padding;
-        }
-        else if (value > 0xFF)
+        if (value > 0xFF)
         {
             return ZYAN_STATUS_INVALID_ARGUMENT;
         }
@@ -274,15 +266,8 @@ ZyanStatus ZydisFormatterSetProperty(ZydisFormatter* formatter, ZydisFormatterPr
     }
     case ZYDIS_FORMATTER_PROP_IMM_PADDING:
     {
-        if ((ZydisPadding)value == ZYDIS_PADDING_AUTO)
-        {
-            if ((ZyanUSize)formatter->style > ZYDIS_FORMATTER_STYLE_MAX_VALUE)
-            {
-                return ZYAN_STATUS_INVALID_ARGUMENT;
-            }
-            formatter->imm_padding = FORMATTER_PRESETS[formatter->style]->imm_padding;
-        }
-        else if (value > 0xFF)
+        if (((ZydisPadding)value != ZYDIS_PADDING_AUTO) &&
+            (value > 0xFF))
         {
             return ZYAN_STATUS_INVALID_ARGUMENT;
         }


### PR DESCRIPTION
A DISP_PADDING of ZYDIS_PADDING_AUTO is resolved to the style preset in ZydisFormatterSetProperty, then immediately overwritten by the unconditional disp_padding = value, so it stays at -1. The AT&T/Intel displacement printers pass disp_padding straight to the number formatter with no AUTO handling (unlike imm/addr), so SetProperty returns SUCCESS but every later format of a memory operand with a displacement fails with INSUFFICIENT_BUFFER_SIZE. Move the assignment into an else.