### PR TITLE
att: apply case_mnemonic to size suffix in print_mnemonic

### DIFF
--- a/src/FormatterATT.c
+++ b/src/FormatterATT.c
@@ -338,13 +338,13 @@ ZyanStatus ZydisFormatterATTPrintMnemonic(const ZydisFormatter* formatter,
 
     switch (size)
     {
-    case   8: ZYAN_CHECK(ZydisStringAppendShort(&buffer->string, &STR_SIZE_8_ATT  )); break;
-    case  16: ZYAN_CHECK(ZydisStringAppendShort(&buffer->string, &STR_SIZE_16_ATT )); break;
-    case  32: ZYAN_CHECK(ZydisStringAppendShort(&buffer->string, &STR_SIZE_32_ATT )); break;
-    case  64: ZYAN_CHECK(ZydisStringAppendShort(&buffer->string, &STR_SIZE_64_ATT )); break;
-    case 128: ZYAN_CHECK(ZydisStringAppendShort(&buffer->string, &STR_SIZE_128_ATT)); break;
-    case 256: ZYAN_CHECK(ZydisStringAppendShort(&buffer->string, &STR_SIZE_256_ATT)); break;
-    case 512: ZYAN_CHECK(ZydisStringAppendShort(&buffer->string, &STR_SIZE_512_ATT)); break;
+    case   8: ZYAN_CHECK(ZydisStringAppendShortCase(&buffer->string, &STR_SIZE_8_ATT  , formatter->case_mnemonic)); break;
+    case  16: ZYAN_CHECK(ZydisStringAppendShortCase(&buffer->string, &STR_SIZE_16_ATT , formatter->case_mnemonic)); break;
+    case  32: ZYAN_CHECK(ZydisStringAppendShortCase(&buffer->string, &STR_SIZE_32_ATT , formatter->case_mnemonic)); break;
+    case  64: ZYAN_CHECK(ZydisStringAppendShortCase(&buffer->string, &STR_SIZE_64_ATT , formatter->case_mnemonic)); break;
+    case 128: ZYAN_CHECK(ZydisStringAppendShortCase(&buffer->string, &STR_SIZE_128_ATT, formatter->case_mnemonic)); break;
+    case 256: ZYAN_CHECK(ZydisStringAppendShortCase(&buffer->string, &STR_SIZE_256_ATT, formatter->case_mnemonic)); break;
+    case 512: ZYAN_CHECK(ZydisStringAppendShortCase(&buffer->string, &STR_SIZE_512_ATT, formatter->case_mnemonic)); break;
     default:
         break;
     }


### PR DESCRIPTION
The AT&T operand-size suffix appended at the bottom of ZydisFormatterATTPrintMnemonic uses ZydisStringAppendShort, while the mnemonic and the NF suffix above already go through ZydisStringAppendShortCase with formatter->case_mnemonic. With ZYDIS_FORMATTER_PROP_UPPERCASE_MNEMONIC enabled the result is mixed-case output, e.g. `MOVl $0x12345678, (%rax)` for a 32-bit memory move. Switch the seven branches in the size switch to ZydisStringAppendShortCase with the same case_mnemonic so the suffix follows the mnemonic.