### PR TITLE
Encoder: byte-swap rip-rel patch on big endian

### DIFF
--- a/src/Encoder.c
+++ b/src/Encoder.c
@@ -4871,7 +4871,13 @@ ZYDIS_EXPORT ZyanStatus ZydisEncoderEncodeInstructionAbsolute(ZydisEncoderReques
             disp_offset += 1;
         }
         ZYAN_ASSERT(instruction_size > disp_offset);
+#if ZYAN_ENDIAN == ZYAN_LITTLE_ENDIAN
         ZYAN_MEMCPY((ZyanU8 *)buffer + instruction_size - disp_offset, &rip_rel, sizeof(ZyanI32));
+#else
+        const ZyanU32 rip_rel_le = ZYAN_BYTESWAP32((ZyanU32)rip_rel);
+        ZYAN_MEMCPY((ZyanU8 *)buffer + instruction_size - disp_offset, &rip_rel_le,
+            sizeof(rip_rel_le));
+#endif
         op_rip_rel->mem.displacement = rip_rel;
     }
 


### PR DESCRIPTION
ZydisEncoderEncodeInstructionAbsolute patches the rip-relative
displacement of an emitted instruction with a bare MEMCPY of 4 bytes
from a ZyanI64, which writes the high half in native byte order on
big endian hosts. The 80a9c01 BE-support commit updated ZydisEmitUInt
but missed this open-coded site. Mirror its swap-then-MEMCPY shape.