### PR TITLE
Decoder: drop dead duplicate EVEX V4 check after assignment

### DIFF
--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -656,11 +656,6 @@ static ZyanStatus ZydisDecodeEVEX(const ZydisDecoder* decoder, ZydisDecoderConte
     context->vector_unified.vvvv = 0x0F & ~instruction->raw.evex.vvvv;
     context->vector_unified.mask = instruction->raw.evex.aaa;
 
-    if (!instruction->raw.evex.V4 && (instruction->machine_mode != ZYDIS_MACHINE_MODE_LONG_64))
-    {
-        return ZYDIS_STATUS_MALFORMED_EVEX;
-    }
-
     if (!instruction->raw.evex.b && (context->vector_unified.LL == 3))
     {
         // LL = 3 is only valid for instructions with embedded rounding control


### PR DESCRIPTION
Noticed ZydisDecodeEVEX repeats the `!raw.evex.V4 && machine_mode != LONG_64` MALFORMED_EVEX guard after the vector_unified assignments. The earlier identical guard already returns for the same inputs and neither operand is mutated in between, so the second block is unreachable.