### PR TITLE
fix dropped leading zero in hex append at padding boundary

### DIFF
--- a/src/String.c
+++ b/src/String.c
@@ -199,20 +199,20 @@ static ZyanStatus ZydisStringAppendHexU32(ZyanString* string, ZyanU32 value, Zya
             {
                 continue;
             }
-            const ZyanU8 zero = force_leading_number && (v > 9) && (padding_length <= i) ? 1 : 0;
+            const ZyanU8 zero = force_leading_number && (v > 9) && (padding_length <= i + 1) ? 1 : 0;
             if (remaining <= (ZyanUSize)i + zero)
             {
                 return ZYAN_STATUS_INSUFFICIENT_BUFFER_SIZE;
             }
             buffer = (char*)string->vector.data + len - 1;
-            if (zero)
-            {
-                buffer[n++] = '0';
-            }
             if (padding_length > i)
             {
                 n = padding_length - i - 1;
                 ZYAN_MEMSET(buffer, '0', n);
+            }
+            if (zero)
+            {
+                buffer[n++] = '0';
             }
         }
         ZYAN_ASSERT(buffer);
@@ -273,20 +273,20 @@ static ZyanStatus ZydisStringAppendHexU64(ZyanString* string, ZyanU64 value, Zya
             {
                 continue;
             }
-            const ZyanU8 zero = force_leading_number && (v > 9) && (padding_length <= i) ? 1 : 0;
+            const ZyanU8 zero = force_leading_number && (v > 9) && (padding_length <= i + 1) ? 1 : 0;
             if (remaining <= (ZyanUSize)i + zero)
             {
                 return ZYAN_STATUS_INSUFFICIENT_BUFFER_SIZE;
             }
             buffer = (char*)string->vector.data + len - 1;
-            if (zero)
-            {
-                buffer[n++] = '0';
-            }
             if (padding_length > i)
             {
                 n = padding_length - i - 1;
                 ZYAN_MEMSET(buffer, '0', n);
+            }
+            if (zero)
+            {
+                buffer[n++] = '0';
             }
         }
         ZYAN_ASSERT(buffer);


### PR DESCRIPTION
ZydisStringAppendHexU with force_leading_number set is documented to prepend a 0 when the first character would be non-numeric, but it skipped that when padding_length equalled the significant nibble count:

    ZydisStringAppendHexU(&s, 0xAB, 2, /*force=*/TRUE, ...)  -> "ab"   (want "0ab")
    ZydisStringAppendHexU(&s, 0xABCD, 4, /*force=*/TRUE, ...) -> "abcd" (want "0abcd")

The zero guard used padding_length <= i, but a value has i+1 significant nibbles, so at padding_length == i+1 neither the guard nor the padding wrote a leading zero. Widen it to i + 1 and emit the forced zero after the padding block, since that block reassigns n. Same in the U32 and U64 paths.