### PR TITLE
ignore SIB scale for MIB operands in ZydisCalcAbsoluteAddressEx

### DIFF
--- a/src/Utils.c
+++ b/src/Utils.c
@@ -136,10 +136,17 @@ ZyanStatus ZydisCalcAbsoluteAddressEx(const ZydisDecodedInstruction* instruction
     const ZydisDecodedOperand* operand, ZyanU64 runtime_address,
     const ZydisRegisterContext* register_context, ZyanU64* result_address)
 {
-    // TODO: Test this with AGEN/MIB operands
     // TODO: Add support for Gather/Scatter instructions
 
     if (!instruction || !operand || !register_context || !result_address)
+    {
+        return ZYAN_STATUS_INVALID_ARGUMENT;
+    }
+
+    // `MIB` operands (`BNDLDX`/`BNDSTX`) have `MPX`-specific addressing semantics that
+    // don't map to a single effective address, so they are not supported here
+    if ((operand->type == ZYDIS_OPERAND_TYPE_MEMORY) &&
+        (operand->mem.type == ZYDIS_MEMOP_TYPE_MIB))
     {
         return ZYAN_STATUS_INVALID_ARGUMENT;
     }


### PR DESCRIPTION
ZydisCalcAbsoluteAddressEx scales the index by mem.scale at Utils.c:171, but MIB operands (BNDLDX/BNDSTX) ignore the SIB scale, which the encoder already drops in DecodedInstructionToEncoderRequest. Use a scale of 1 for MIB so the result matches base+index+disp.