### PR TITLE
compute REX.B node index with bitwise or in ZydisNodeHandlerRexB

### DIFF
--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -4304,7 +4304,7 @@ static ZyanStatus ZydisNodeHandlerRexB(const ZydisDecoderContext* context,
         ZYAN_UNREACHABLE;
     }
 
-    *index = context->vector_unified.B3 + context->vector_unified.B4 ? 1 : 0;
+    *index = context->vector_unified.B3 | context->vector_unified.B4;
 
     return ZYAN_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Noticed ZydisNodeHandlerRexB derives the selector index with `B3 + B4 ? 1 : 0`, which only lands on the right 0/1 child because `+` binds tighter than `?:` and both bits are always masked to 0/1. The sibling selector handlers (RexW, EvexND, EvexNF, MvexE) assign the bit directly. Using `B3 | B4` keeps the result a plain 0/1 without leaning on precedence. No behavior change for the 0x90 nop/xchg disambiguation across B3, B4 (APX r16-r31) and both-set; both regression suites pass.