### PR TITLE
Decoder: use vector_unified.LL for the L'L check in NF handler

### DIFF
--- a/include/Zydis/DecoderTypes.h
+++ b/include/Zydis/DecoderTypes.h
@@ -1609,7 +1609,6 @@ typedef struct ZydisDecoderContext_
         ZyanU8 X4;
         ZyanU8 B3;
         ZyanU8 B4;
-        ZyanU8 L;
         ZyanU8 LL;
         ZyanU8 V4;
         ZyanU8 vvvv;

--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -488,7 +488,6 @@ static ZyanStatus ZydisDecodeXOP(ZydisDecoderContext* context,
     context->vector_unified.R3   = 0x01 & ~instruction->raw.xop.R;
     context->vector_unified.X3   = 0x01 & ~instruction->raw.xop.X;
     context->vector_unified.B3   = 0x01 & ~instruction->raw.xop.B;
-    context->vector_unified.L    = instruction->raw.xop.L;
     context->vector_unified.LL   = instruction->raw.xop.L;
     context->vector_unified.vvvv = (0x0F & ~instruction->raw.xop.vvvv);
 
@@ -563,7 +562,6 @@ static ZyanStatus ZydisDecodeVEX(ZydisDecoderContext* context,
     context->vector_unified.R3   = 0x01 & ~instruction->raw.vex.R;
     context->vector_unified.X3   = 0x01 & ~instruction->raw.vex.X;
     context->vector_unified.B3   = 0x01 & ~instruction->raw.vex.B;
-    context->vector_unified.L    = instruction->raw.vex.L;
     context->vector_unified.LL   = instruction->raw.vex.L;
     context->vector_unified.vvvv = (0x0F & ~instruction->raw.vex.vvvv);
 

--- a/src/Decoder.c
+++ b/src/Decoder.c
@@ -4382,7 +4382,7 @@ static ZyanStatus ZydisNodeHandlerEvexNF(ZydisDecoderContext* context,
 
     // Error conditions
 
-    if (instruction->raw.evex.z || context->vector_unified.L || 
+    if (instruction->raw.evex.z || context->vector_unified.LL ||
         (context->vector_unified.mask & 0x03))
     {
         return ZYDIS_STATUS_DECODING_ERROR;


### PR DESCRIPTION
The NF node handler validates the EVEX prefix of APX no-flags instructions, and part of that is rejecting a non-zero L'L, which is reserved for these GPR-form encodings. The test reads context->vector_unified.L, but that field is only ever written on the VEX and XOP paths; the EVEX decoder populates vector_unified.LL instead and leaves .L at its zero-initialised value. So for any EVEX instruction the L'L term is always false and this part of the reserved-field check never fires. I noticed it while reading the sibling SCC handler just below, which guards the same thing correctly with vector_unified.LL. In practice the vector-length filter in the decode tree already rejects the affected encodings, so decoder output is unchanged today, but the handler should still enforce what it reads and stay consistent with the SCC path. The change is a single field swap inside ZydisNodeHandlerEvexNF.