### PR TITLE
Formatter: apply AUTO imm padding only for hex base in print_imm

### DIFF
--- a/src/FormatterBase.c
+++ b/src/FormatterBase.c
@@ -329,28 +329,32 @@ ZyanStatus ZydisFormatterBasePrintIMM(const ZydisFormatter* formatter,
     switch (context->instruction->operand_width)
     {
     case 8:
-        if (formatter->imm_padding == ZYDIS_PADDING_AUTO)
+        if ((formatter->imm_padding == ZYDIS_PADDING_AUTO) &&
+            (formatter->imm_base == ZYDIS_NUMERIC_BASE_HEX))
         {
             padding =  2;
         }
         value = (ZyanU8 )context->operand->imm.value.u;
         break;
     case 16:
-        if (formatter->imm_padding == ZYDIS_PADDING_AUTO)
+        if ((formatter->imm_padding == ZYDIS_PADDING_AUTO) &&
+            (formatter->imm_base == ZYDIS_NUMERIC_BASE_HEX))
         {
             padding =  4;
         }
         value = (ZyanU16)context->operand->imm.value.u;
         break;
     case 32:
-        if (formatter->imm_padding == ZYDIS_PADDING_AUTO)
+        if ((formatter->imm_padding == ZYDIS_PADDING_AUTO) &&
+            (formatter->imm_base == ZYDIS_NUMERIC_BASE_HEX))
         {
             padding =  8;
         }
         value = (ZyanU32)context->operand->imm.value.u;
         break;
     case 64:
-        if (formatter->imm_padding == ZYDIS_PADDING_AUTO)
+        if ((formatter->imm_padding == ZYDIS_PADDING_AUTO) &&
+            (formatter->imm_base == ZYDIS_NUMERIC_BASE_HEX))
         {
             padding = 16;
         }


### PR DESCRIPTION
ZydisFormatterBasePrintIMM resolves an immediate padding of ZYDIS_PADDING_AUTO to the operand width regardless of the numeric base, so with the immediate base set to decimal and imm padding left on auto a small value like 5 comes out as 00000005 instead of 5. The address printers and the documented behaviour only apply the auto width padding for hexadecimal, so this looks like an oversight in print_imm. This gates the auto width on hex base in each width case, mirroring PrintAddressABS/REL, and leaves the default hex output unchanged.